### PR TITLE
Add modifiers to check for existing authorized addresses

### DIFF
--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -30,6 +30,16 @@ contract Proxy is Ownable {
         _;
     }
 
+    modifier targetAuthorized(address target) {
+        if (!authorized[target]) throw;
+        _;
+    }
+
+    modifier targetNotAuthorized(address target) {
+        if (authorized[target]) throw;
+        _;
+    }
+
     mapping (address => bool) public authorized;
     address[] public authorities;
 
@@ -45,6 +55,7 @@ contract Proxy is Ownable {
     /// @return Success of authorization.
     function addAuthorizedAddress(address target)
         onlyOwner
+        targetNotAuthorized(target)
         returns (bool success)
     {
         authorized[target] = true;
@@ -58,6 +69,7 @@ contract Proxy is Ownable {
     /// @return Success of deauthorization.
     function removeAuthorizedAddress(address target)
         onlyOwner
+        targetAuthorized(target)
         returns (bool success)
     {
         delete authorized[target];

--- a/test/ts/proxy/auth.ts
+++ b/test/ts/proxy/auth.ts
@@ -34,6 +34,15 @@ contract('Proxy', (accounts: string[]) => {
       const isAuthorized = await proxy.authorized.call(authorized);
       assert(isAuthorized);
     });
+
+    it('should throw if owner attempts to authorize a duplicate address', async () => {
+      try {
+        await proxy.addAuthorizedAddress(authorized, { from: owner });
+        throw new Error('addAuthorizedAddress succeeded when it should have thrown');
+      } catch (err) {
+        testUtil.assertThrow(err);
+      }
+    });
   });
 
   describe('removeAuthorizedAddress', () => {
@@ -53,6 +62,15 @@ contract('Proxy', (accounts: string[]) => {
 
       const isAuthorized = await proxy.authorized.call(notAuthorized);
       assert(!isAuthorized);
+    });
+
+    it('should throw if owner attempts to remove an address that is not authorized', async () => {
+      try {
+        await proxy.removeAuthorizedAddress(notAuthorized, { from: owner });
+        throw new Error('removeAuthorizedAddress succeeded when it should have thrown');
+      } catch (err) {
+        testUtil.assertThrow(err);
+      }
     });
   });
 


### PR DESCRIPTION
This PR adds modifiers to `addAuthorizedAddress` and `removeAuthorizedAddress` to prevent authorizing duplicate addresses and to prevent these functions from always returning `true`.