### PR TITLE
Change fillValueM => fillValueT

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -33,7 +33,7 @@ contract Exchange is SafeMath {
     uint8 constant ERROR_CANCEL_EXPIRED = 4;         // Order has already expired
     uint8 constant ERROR_CANCEL_NO_VALUE = 5;        // Order has already been fully filled or cancelled
 
-    address public PROTOCOL_TOKEN;
+    address public ZRX;
     address public PROXY;
 
     mapping (bytes32 => uint) public fills;
@@ -71,8 +71,8 @@ contract Exchange is SafeMath {
 
     event LogError(uint8 indexed errorId, bytes32 indexed orderHash);
 
-    function Exchange(address _protocolToken, address _proxy) {
-        PROTOCOL_TOKEN = _protocolToken;
+    function Exchange(address _zrx, address _proxy) {
+        ZRX = _zrx;
         PROXY = _proxy;
     }
 
@@ -169,7 +169,7 @@ contract Exchange is SafeMath {
         if (feeRecipient != address(0)) {
             if (fees[0] > 0) {
                 assert(transferViaProxy(
-                    PROTOCOL_TOKEN,
+                    ZRX,
                     traders[0],
                     feeRecipient,
                     getPartialValue(values[1], filledValueT, fees[0])
@@ -177,7 +177,7 @@ contract Exchange is SafeMath {
             }
             if (fees[1] > 0) {
                 assert(transferViaProxy(
-                    PROTOCOL_TOKEN,
+                    ZRX,
                     msg.sender,
                     feeRecipient,
                     getPartialValue(values[1], filledValueT, fees[1])
@@ -677,10 +677,10 @@ contract Exchange is SafeMath {
         if (feeRecipient != address(0)) {
             uint feeValueM = getPartialValue(values[1], fillValueT, fees[0]);
             uint feeValueT = getPartialValue(values[1], fillValueT, fees[1]);
-            if (   getBalance(PROTOCOL_TOKEN, traders[0]) < feeValueM
-                || getAllowance(PROTOCOL_TOKEN, traders[0]) < feeValueM
-                || getBalance(PROTOCOL_TOKEN, traders[1]) < feeValueT
-                || getAllowance(PROTOCOL_TOKEN, traders[1]) < feeValueT
+            if (   getBalance(ZRX, traders[0]) < feeValueM
+                || getAllowance(ZRX, traders[0]) < feeValueM
+                || getBalance(ZRX, traders[1]) < feeValueT
+                || getAllowance(ZRX, traders[1]) < feeValueT
             ) return false;
         }
         return true;

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -269,7 +269,7 @@ contract Exchange is SafeMath {
     /// @param fillValueT Desired amount of tokenT to fill in order.
     /// @param v ECDSA signature parameter v.
     /// @param rs Array of ECDSA signature parameters r and s.
-    /// @return Success of entire fillValueM being filled.
+    /// @return Success of entire fillValueT being filled.
     function fillOrKill(
         address[2] traders,
         address[2] tokens,
@@ -349,7 +349,7 @@ contract Exchange is SafeMath {
     /// @param fillValuesT Array of desired amounts of tokenT to fill in orders.
     /// @param v Array ECDSA signature v parameters.
     /// @param rs Array of ECDSA signature parameters r and s tuples.
-    /// @return Success of all orders being filled with respective fillValueM.
+    /// @return Success of all orders being filled with respective fillValueT.
     function batchFillOrKill(
         address[2][] traders,
         address[2][] tokens,
@@ -378,7 +378,7 @@ contract Exchange is SafeMath {
         return true;
     }
 
-    /// @dev Synchronously executes multiple fill orders in a single transaction until total fillValueM filled.
+    /// @dev Synchronously executes multiple fill orders in a single transaction until total fillValueT filled.
     /// @param traders Array of order maker and taker address tuples.
     /// @param tokens Array of order tokenM and tokenT address tuples.
     /// @param feeRecipients Array of addresses that receive order fees.
@@ -389,7 +389,7 @@ contract Exchange is SafeMath {
     /// @param v Array ECDSA signature v parameters.
     /// @param rs Array of ECDSA signature parameters r and s tuples.
     /// @param shouldCheckTransfer Test if transfers will fail before attempting.
-    /// @return Total amount of fillValueM filled in orders.
+    /// @return Total amount of fillValueT filled in orders.
     function fillUpTo(
         address[2][] traders,
         address[2][] tokens,
@@ -541,7 +541,7 @@ contract Exchange is SafeMath {
         return (target < 10**3 && mulmod(target, numerator, denominator) != 0);
     }
 
-    /// @dev Calculates partial value given fillValueM and order valueM.
+    /// @dev Calculates partial value given a fillValue and a corresponding total value.
     /// @param value Amount of token specified in order.
     /// @param fillValue Amount of token to be filled.
     /// @param target Value to calculate partial.

--- a/test/ts/exchange/core.ts
+++ b/test/ts/exchange/core.ts
@@ -242,7 +242,7 @@ contract('Exchange', (accounts: string[]) => {
                    add(balances[feeRecipient][zrx.address], add(feeValueM, feeValueT)));
     });
 
-    it('should fill remaining value if fillValueM > remaining valueM', async () => {
+    it('should fill remaining value if fillValueT > remaining valueT', async () => {
       const fillValueT = div(order.params.valueT, 2);
       await exWrapper.fillAsync(order, taker, { fillValueT });
 

--- a/test/ts/exchange/core.ts
+++ b/test/ts/exchange/core.ts
@@ -125,17 +125,18 @@ contract('Exchange', (accounts: string[]) => {
         valueT: toSmallestUnits(100),
       });
 
-      const filledAmountMBefore = await exchange.fills.call(order.params.orderHashHex);
-      assert.equal(filledAmountMBefore, 0, 'filledAmountMBefore should be 0');
+      const filledAmountTBefore = await exchange.fills.call(order.params.orderHashHex);
+      assert.equal(filledAmountTBefore, 0, 'filledAmountMBefore should be 0');
 
-      const fillValueM = div(order.params.valueM, 2);
-      await exWrapper.fillAsync(order, taker, { fillValueM });
+      const fillValueT = div(order.params.valueT, 2);
+      await exWrapper.fillAsync(order, taker, { fillValueT });
 
-      const filledAmountMAfter = await exchange.fills.call(order.params.orderHashHex);
-      assert.equal(filledAmountMAfter, fillValueM, 'filledAmountMAfter should be same as fillValueM');
+      const filledAmountTAfter = await exchange.fills.call(order.params.orderHashHex);
+      assert.equal(filledAmountTAfter, fillValueT, 'filledAmountTAfter should be same as fillValueT');
 
       const newBalances = await dmyBalances.getAsync();
-      const fillValueT = div(mul(fillValueM, order.params.valueT), order.params.valueM);
+
+      const fillValueM = div(mul(fillValueT, order.params.valueM), order.params.valueT);
       const feeValueM = div(mul(order.params.feeM, fillValueM), order.params.valueM);
       const feeValueT = div(mul(order.params.feeT, fillValueM), order.params.valueM);
       assert.equal(newBalances[maker][order.params.tokenM], sub(balances[maker][order.params.tokenM], fillValueM));
@@ -154,18 +155,18 @@ contract('Exchange', (accounts: string[]) => {
         valueT: toSmallestUnits(100),
       });
 
-      const filledAmountMBefore = await exchange.fills.call(order.params.orderHashHex);
-      assert.equal(filledAmountMBefore, 0, 'filledAmountMBefore should be 0');
+      const filledAmountTBefore = await exchange.fills.call(order.params.orderHashHex);
+      assert.equal(filledAmountTBefore, 0, 'filledAmountTBefore should be 0');
 
-      const fillValueM = div(order.params.valueM, 2);
-      await exWrapper.fillAsync(order, taker, { fillValueM });
+      const fillValueT = div(order.params.valueT, 2);
+      await exWrapper.fillAsync(order, taker, { fillValueT });
 
-      const filledAmountMAfter = await exchange.fills.call(order.params.orderHashHex);
-      assert.equal(filledAmountMAfter, fillValueM, 'filledAmountMAfter should be same as fillValueM');
+      const filledAmountTAfter = await exchange.fills.call(order.params.orderHashHex);
+      assert.equal(filledAmountTAfter, fillValueT, 'filledAmountTAfter should be same as fillValueT');
 
       const newBalances = await dmyBalances.getAsync();
 
-      const fillValueT = div(mul(fillValueM, order.params.valueT), order.params.valueM);
+      const fillValueM = div(mul(fillValueT, order.params.valueM), order.params.valueT);
       const feeValueM = div(mul(order.params.feeM, fillValueM), order.params.valueM);
       const feeValueT = div(mul(order.params.feeT, fillValueM), order.params.valueM);
       assert.equal(newBalances[maker][order.params.tokenM], sub(balances[maker][order.params.tokenM], fillValueM));
@@ -184,18 +185,18 @@ contract('Exchange', (accounts: string[]) => {
         valueT: toSmallestUnits(200),
       });
 
-      const filledAmountMBefore = await exchange.fills.call(order.params.orderHashHex);
-      assert.equal(filledAmountMBefore, 0, 'filledAmountMBefore should be 0');
+      const filledAmountTBefore = await exchange.fills.call(order.params.orderHashHex);
+      assert.equal(filledAmountTBefore, 0, 'filledAmountTBefore should be 0');
 
-      const fillValueM = div(order.params.valueM, 2);
-      await exWrapper.fillAsync(order, taker, { fillValueM });
+      const fillValueT = div(order.params.valueT, 2);
+      await exWrapper.fillAsync(order, taker, { fillValueT });
 
-      const filledAmountMAfter = await exchange.fills.call(order.params.orderHashHex);
-      assert.equal(filledAmountMAfter, fillValueM, 'filledAmountMAfter should be same as fillValueM');
+      const filledAmountTAfter = await exchange.fills.call(order.params.orderHashHex);
+      assert.equal(filledAmountTAfter, fillValueT, 'filledAmountTAfter should be same as fillValueT');
 
       const newBalances = await dmyBalances.getAsync();
 
-      const fillValueT = div(mul(fillValueM, order.params.valueT), order.params.valueM);
+      const fillValueM = div(mul(fillValueT, order.params.valueM), order.params.valueT);
       const feeValueM = div(mul(order.params.feeM, fillValueM), order.params.valueM);
       const feeValueT = div(mul(order.params.feeT, fillValueM), order.params.valueM);
       assert.equal(newBalances[maker][order.params.tokenM], sub(balances[maker][order.params.tokenM], fillValueM));
@@ -215,20 +216,20 @@ contract('Exchange', (accounts: string[]) => {
         valueT: toSmallestUnits(200),
       });
 
-      const filledAmountMBefore = await exchange.fills.call(order.params.orderHashHex);
-      assert.equal(filledAmountMBefore, 0, 'filledAmountMBefore should be 0');
+      const filledAmountTBefore = await exchange.fills.call(order.params.orderHashHex);
+      assert.equal(filledAmountTBefore, 0, 'filledAmountTBefore should be 0');
 
-      const fillValueM = div(order.params.valueM, 2);
-      await exWrapper.fillAsync(order, taker, { fillValueM });
+      const fillValueT = div(order.params.valueT, 2);
+      await exWrapper.fillAsync(order, taker, { fillValueT });
 
-      const filledAmountMAfter = await exchange.fills.call(order.params.orderHashHex);
-      const expectedFillAmountMAfter = add(fillValueM, filledAmountMBefore);
-      assert.equal(filledAmountMAfter.toString(), expectedFillAmountMAfter,
-                   'filledAmountMAfter should be same as fillValueM');
+      const filledAmountTAfter = await exchange.fills.call(order.params.orderHashHex);
+      const expectedFillAmountTAfter = add(fillValueT, filledAmountTBefore);
+      assert.equal(filledAmountTAfter.toString(), expectedFillAmountTAfter,
+                   'filledAmountTAfter should be same as fillValueT');
 
       const newBalances = await dmyBalances.getAsync();
 
-      const fillValueT = div(mul(fillValueM, order.params.valueT), order.params.valueM);
+      const fillValueM = div(mul(fillValueT, order.params.valueM), order.params.valueT);
       const feeValueM = div(mul(order.params.feeM, fillValueM), order.params.valueM);
       const feeValueT = div(mul(order.params.feeT, fillValueM), order.params.valueM);
       assert.equal(newBalances[maker][order.params.tokenM], sub(balances[maker][order.params.tokenM], fillValueM));
@@ -242,12 +243,12 @@ contract('Exchange', (accounts: string[]) => {
     });
 
     it('should fill remaining value if fillValueM > remaining valueM', async () => {
-      const fillValueM = div(order.params.valueM, 2);
-      await exWrapper.fillAsync(order, taker, { fillValueM });
+      const fillValueT = div(order.params.valueT, 2);
+      await exWrapper.fillAsync(order, taker, { fillValueT });
 
-      const res = await exWrapper.fillAsync(order, taker, { fillValueM: order.params.valueM });
+      const res = await exWrapper.fillAsync(order, taker, { fillValueT: order.params.valueT });
 
-      assert.equal(res.logs[0].args.filledValueM.toString(), sub(order.params.valueM, fillValueM));
+      assert.equal(res.logs[0].args.filledValueT.toString(), sub(order.params.valueT, fillValueT));
       const newBalances = await dmyBalances.getAsync();
 
       assert.equal(newBalances[maker][order.params.tokenM],
@@ -265,7 +266,7 @@ contract('Exchange', (accounts: string[]) => {
     });
 
     it('should log 1 event', async () => {
-      const res = await exWrapper.fillAsync(order, taker, { fillValueM: div(order.params.valueM, 2) });
+      const res = await exWrapper.fillAsync(order, taker, { fillValueT: div(order.params.valueT, 2) });
       assert.equal(res.logs.length, 1);
     });
 
@@ -389,21 +390,21 @@ contract('Exchange', (accounts: string[]) => {
 
     it('should be able to cancel a full order', async () => {
       await exWrapper.cancelAsync(order, maker);
-      await exWrapper.fillAsync(order, taker, { fillValueM: div(order.params.valueM, 2) });
+      await exWrapper.fillAsync(order, taker, { fillValueT: div(order.params.valueT, 2) });
 
       const newBalances = await dmyBalances.getAsync();
       assert.deepEqual(newBalances, balances);
     });
 
     it('should be able to cancel part of an order', async () => {
-      const cancelValueM = div(order.params.valueM, 2);
-      await exWrapper.cancelAsync(order, maker, { cancelValueM });
+      const cancelValueT = div(order.params.valueT, 2);
+      await exWrapper.cancelAsync(order, maker, { cancelValueT });
 
-      const res = await exWrapper.fillAsync(order, taker, { fillValueM: order.params.valueM });
-      assert.equal(res.logs[0].args.filledValueM.toString(), sub(order.params.valueM, cancelValueM));
+      const res = await exWrapper.fillAsync(order, taker, { fillValueT: order.params.valueT });
+      assert.equal(res.logs[0].args.filledValueT.toString(), sub(order.params.valueT, cancelValueT));
 
       const newBalances = await dmyBalances.getAsync();
-      const cancelValueT = div(mul(cancelValueM, order.params.valueT), order.params.valueM);
+      const cancelValueM = div(mul(cancelValueT, order.params.valueM), order.params.valueT);
       const feeValueM = div(mul(order.params.feeM, cancelValueM), order.params.valueM);
       const feeValueT = div(mul(order.params.feeT, cancelValueM), order.params.valueM);
       assert.equal(newBalances[maker][order.params.tokenM], sub(balances[maker][order.params.tokenM], cancelValueM));
@@ -417,7 +418,7 @@ contract('Exchange', (accounts: string[]) => {
     });
 
     it('should log 1 event', async () => {
-      const res = await exWrapper.cancelAsync(order, maker, { cancelValueM: div(order.params.valueM, 2) });
+      const res = await exWrapper.cancelAsync(order, maker, { cancelValueT: div(order.params.valueT, 2) });
       assert.equal(res.logs.length, 1);
     });
 

--- a/util/exchange_wrapper.ts
+++ b/util/exchange_wrapper.ts
@@ -8,9 +8,9 @@ export class ExchangeWrapper {
     this.exchange = exchangeContractInstance;
   }
   public fillAsync(order: Order, from: string,
-                   opts: { fillValueM?: string, shouldCheckTransfer?: boolean } = {}) {
+                   opts: { fillValueT?: string, shouldCheckTransfer?: boolean } = {}) {
     const shouldCheckTransfer = !!opts.shouldCheckTransfer;
-    const params = order.createFill(shouldCheckTransfer, opts.fillValueM);
+    const params = order.createFill(shouldCheckTransfer, opts.fillValueT);
     return this.exchange.fill(
       params.traders,
       params.tokens,
@@ -19,14 +19,14 @@ export class ExchangeWrapper {
       params.values,
       params.fees,
       params.expiration,
-      params.fillValueM,
+      params.fillValueT,
       params.v,
       params.rs,
       { from },
     );
   }
-  public cancelAsync(order: Order, from: string, opts: { cancelValueM?: string } = {}) {
-    const params = order.createCancel(opts.cancelValueM);
+  public cancelAsync(order: Order, from: string, opts: { cancelValueT?: string } = {}) {
+    const params = order.createCancel(opts.cancelValueT);
     return this.exchange.cancel(
       params.traders,
       params.tokens,
@@ -34,13 +34,13 @@ export class ExchangeWrapper {
       params.values,
       params.fees,
       params.expiration,
-      params.cancelValueM,
+      params.cancelValueT,
       { from },
     );
   }
-  public fillOrKillAsync(order: Order, from: string, opts: { fillValueM?: string } = {}) {
+  public fillOrKillAsync(order: Order, from: string, opts: { fillValueT?: string } = {}) {
     const shouldCheckTransfer = false;
-    const params = order.createFill(shouldCheckTransfer, opts.fillValueM);
+    const params = order.createFill(shouldCheckTransfer, opts.fillValueT);
     return this.exchange.fillOrKill(
       params.traders,
       params.tokens,
@@ -48,15 +48,15 @@ export class ExchangeWrapper {
       params.values,
       params.fees,
       params.expiration,
-      params.fillValueM,
+      params.fillValueT,
       params.v,
       params.rs,
       { from },
     );
   }
-  public batchFillAsync(orders: Order[], from: string, opts: { fillValuesM?: string[] } = {}) {
+  public batchFillAsync(orders: Order[], from: string, opts: { fillValuesT?: string[] } = {}) {
     const shouldCheckTransfer = false;
-    const params = formatters.createBatchFill(orders, shouldCheckTransfer, opts.fillValuesM);
+    const params = formatters.createBatchFill(orders, shouldCheckTransfer, opts.fillValuesT);
     return this.exchange.batchFill(
       params.traders,
       params.tokens,
@@ -65,15 +65,15 @@ export class ExchangeWrapper {
       params.values,
       params.fees,
       params.expirations,
-      params.fillValuesM,
+      params.fillValuesT,
       params.v,
       params.rs,
       { from },
     );
   }
-  public fillUpToAsync(orders: Order[], from: string, opts: { fillValueM?: string } = {}) {
+  public fillUpToAsync(orders: Order[], from: string, opts: { fillValueT?: string } = {}) {
     const shouldCheckTransfer = false;
-    const params = formatters.createFillUpTo(orders, shouldCheckTransfer, opts.fillValueM);
+    const params = formatters.createFillUpTo(orders, shouldCheckTransfer, opts.fillValueT);
     return this.exchange.fillUpTo(
       params.traders,
       params.tokens,
@@ -82,14 +82,14 @@ export class ExchangeWrapper {
       params.values,
       params.fees,
       params.expirations,
-      params.fillValueM,
+      params.fillValueT,
       params.v,
       params.rs,
       { from },
     );
   }
-  public batchCancelAsync(orders: Order[], from: string, opts: { cancelValuesM?: string[] } = {}) {
-    const params = formatters.createBatchCancel(orders, opts.cancelValuesM);
+  public batchCancelAsync(orders: Order[], from: string, opts: { cancelValuesT?: string[] } = {}) {
+    const params = formatters.createBatchCancel(orders, opts.cancelValuesT);
     return this.exchange.batchCancel(
       params.traders,
       params.tokens,
@@ -97,7 +97,7 @@ export class ExchangeWrapper {
       params.values,
       params.fees,
       params.expirations,
-      params.cancelValuesM,
+      params.cancelValuesT,
       { from },
     );
   }

--- a/util/formatters.ts
+++ b/util/formatters.ts
@@ -3,7 +3,7 @@ import { BatchFill, BatchCancel, FillUpTo } from './types';
 import { Order } from './order';
 
 export const formatters = {
-  createBatchFill(orders: Order[], shouldCheckTransfer: boolean, fillValuesM: string[] = []) {
+  createBatchFill(orders: Order[], shouldCheckTransfer: boolean, fillValuesT: string[] = []) {
     const batchFill: BatchFill = {
       traders: [],
       tokens: [],
@@ -12,7 +12,7 @@ export const formatters = {
       values: [],
       fees: [],
       expirations: [],
-      fillValuesM,
+      fillValuesT,
       v: [],
       rs: [],
     };
@@ -25,13 +25,13 @@ export const formatters = {
       batchFill.expirations.push(order.params.expiration);
       batchFill.v.push(order.params.v);
       batchFill.rs.push([order.params.r, order.params.s]);
-      if (fillValuesM.length < orders.length) {
-        batchFill.fillValuesM.push(order.params.valueM);
+      if (fillValuesT.length < orders.length) {
+        batchFill.fillValuesT.push(order.params.valueT);
       }
     });
     return batchFill;
   },
-  createFillUpTo(orders: Order[], shouldCheckTransfer: boolean, fillValueM: string) {
+  createFillUpTo(orders: Order[], shouldCheckTransfer: boolean, fillValueT: string) {
     const fillUpTo: FillUpTo = {
       traders: [],
       tokens: [],
@@ -40,7 +40,7 @@ export const formatters = {
       values: [],
       fees: [],
       expirations: [],
-      fillValueM,
+      fillValueT,
       v: [],
       rs: [],
     };
@@ -56,7 +56,7 @@ export const formatters = {
     });
     return fillUpTo;
   },
-  createBatchCancel(orders: Order[], cancelValuesM: string[] = []) {
+  createBatchCancel(orders: Order[], cancelValuesT: string[] = []) {
     const batchCancel: BatchCancel = {
       traders: [],
       tokens: [],
@@ -64,7 +64,7 @@ export const formatters = {
       values: [],
       fees: [],
       expirations: [],
-      cancelValuesM,
+      cancelValuesT,
     };
     orders.forEach(order => {
       batchCancel.traders.push([order.params.maker, order.params.taker]);
@@ -73,8 +73,8 @@ export const formatters = {
       batchCancel.values.push([order.params.valueM, order.params.valueT]);
       batchCancel.fees.push([order.params.feeM, order.params.feeT]);
       batchCancel.expirations.push(order.params.expiration);
-      if (cancelValuesM.length < orders.length) {
-        batchCancel.cancelValuesM.push(order.params.valueM);
+      if (cancelValuesT.length < orders.length) {
+        batchCancel.cancelValuesT.push(order.params.valueT);
       }
     });
     return batchCancel;

--- a/util/order.ts
+++ b/util/order.ts
@@ -41,7 +41,7 @@ export class Order {
       s: ethUtil.bufferToHex(s),
     });
   }
-  public createFill(shouldCheckTransfer: boolean, fillValueM?: string) {
+  public createFill(shouldCheckTransfer: boolean, fillValueT?: string) {
     const fill = {
       traders: [this.params.maker, this.params.taker],
       tokens: [this.params.tokenM, this.params.tokenT],
@@ -50,13 +50,13 @@ export class Order {
       values: [this.params.valueM, this.params.valueT],
       fees: [this.params.feeM, this.params.feeT],
       expiration: this.params.expiration,
-      fillValueM: fillValueM || this.params.valueM,
+      fillValueT: fillValueT || this.params.valueT,
       v: this.params.v,
       rs: [this.params.r, this.params.s],
     };
     return fill;
   }
-  public createCancel(cancelValueM?: string) {
+  public createCancel(cancelValueT?: string) {
     const cancel = {
       traders: [this.params.maker, this.params.taker],
       tokens: [this.params.tokenM, this.params.tokenT],
@@ -64,7 +64,7 @@ export class Order {
       values: [this.params.valueM, this.params.valueT],
       fees: [this.params.feeM, this.params.feeT],
       expiration: this.params.expiration,
-      cancelValueM: cancelValueM || this.params.valueM,
+      cancelValueT: cancelValueT || this.params.valueT,
     };
     return cancel;
   }

--- a/util/types.ts
+++ b/util/types.ts
@@ -12,7 +12,7 @@ export interface BatchFill {
   values: string[][];
   fees: string[][];
   expirations: number[];
-  fillValuesM: string[];
+  fillValuesT: string[];
   v: number[];
   rs: string[][];
 }
@@ -25,7 +25,7 @@ export interface FillUpTo {
   values: string[][];
   fees: string[][];
   expirations: number[];
-  fillValueM: string;
+  fillValueT: string;
   v: number[];
   rs: string[][];
 }
@@ -37,7 +37,7 @@ export interface BatchCancel {
   values: string[][];
   fees: string[][];
   expirations: number[];
-  cancelValuesM: string[];
+  cancelValuesT: string[];
 }
 
 export interface DefaultOrderParams {


### PR DESCRIPTION
This PR changes all instances of `fillValueM` to `fillValueT`. It is more intuitive for a taker to specify the amount of the token they wish to sell (since they already have that token), rather than the amount of the token they wish to buy. In addition, this change makes `fillUpTo` work much more similarly to a traditional market order.