### PR TITLE
Add salt to order params

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ tokenT | `address` | Address of an ERC20 Token contract.
 valueM | `uint256` | Total units of tokenM offered by maker.
 valueT | `uint256` | Total units of tokenT requested by maker.
 expiration | `uint256` | Time at which the order expires (seconds since unix epoch).
-salt | `uint256` | Arbitrary number.
+salt | `uint256` | Arbitrary number that allows for uniqueness of the order's Keccak SHA3 hash.
 feeRecipient | `address` | Address that recieves transaction fees (optional).
 feeM | `uint256` | Total units of ZRX paid to feeRecipient by maker.
 feeT | `uint256` | Total units of ZRX paid to feeRecipient by taker.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ tokenT | `address` | Address of an ERC20 Token contract.
 valueM | `uint256` | Total units of tokenM offered by maker.
 valueT | `uint256` | Total units of tokenT requested by maker.
 expiration | `uint256` | Time at which the order expires (seconds since unix epoch).
+salt | `uint256` | Arbitrary number.
 feeRecipient | `address` | Address that recieves transaction fees (optional).
 feeM | `uint256` | Total units of ZRX paid to feeRecipient by maker.
 feeT | `uint256` | Total units of ZRX paid to feeRecipient by taker.

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -87,7 +87,7 @@ contract Exchange is SafeMath {
     /// @param shouldCheckTransfer Test if transfer will fail before attempting.
     /// @param values Token values to be traded [valueM, valueT].
     /// @param fees Array of order feeM and feeT.
-    /// @param expiration Time order expires (seconds since unix epoch).
+    /// @param expirationAndSalt Time order expires (seconds since unix epoch) and random number.
     /// @param fillValueT Desired amount of tokenT to fill.
     /// @param v ECDSA signature parameter v.
     /// @param rs Array of ECDSA signature parameters r and s.
@@ -99,7 +99,7 @@ contract Exchange is SafeMath {
         bool shouldCheckTransfer,
         uint[2] values,
         uint[2] fees,
-        uint expiration,
+        uint[2] expirationAndSalt,
         uint fillValueT,
         uint8 v,
         bytes32[2] rs)
@@ -113,10 +113,10 @@ contract Exchange is SafeMath {
             feeRecipient,
             values,
             fees,
-            expiration
+            expirationAndSalt
         );
 
-        if (block.timestamp >= expiration) {
+        if (block.timestamp >= expirationAndSalt[0]) {
             LogError(ERROR_FILL_EXPIRED, orderHash);
             return 0;
         }
@@ -192,7 +192,7 @@ contract Exchange is SafeMath {
             feeRecipient,
             values,
             fees,
-            expiration,
+            expirationAndSalt[0],
             filledValueT,
             orderHash
         );
@@ -205,7 +205,7 @@ contract Exchange is SafeMath {
     /// @param feeRecipient Address that receives order fees.
     /// @param values Array of order valueM and valueT.
     /// @param fees Array of order feeM and feeT.
-    /// @param expiration Time order expires in seconds.
+    /// @param expirationAndSalt Time order expires (seconds since unix epoch) and random number.
     /// @param cancelValueT Desired amount of tokenT to cancel in order.
     /// @return Amount of tokenM cancelled.
     function cancel(
@@ -214,7 +214,7 @@ contract Exchange is SafeMath {
         address feeRecipient,
         uint[2] values,
         uint[2] fees,
-        uint expiration,
+        uint[2] expirationAndSalt,
         uint cancelValueT)
         returns (uint cancelledValueT)
     {
@@ -226,10 +226,10 @@ contract Exchange is SafeMath {
             feeRecipient,
             values,
             fees,
-            expiration
+            expirationAndSalt
         );
 
-        if (block.timestamp >= expiration) {
+        if (block.timestamp >= expirationAndSalt[0]) {
             LogError(ERROR_CANCEL_EXPIRED, orderHash);
             return 0;
         }
@@ -248,7 +248,7 @@ contract Exchange is SafeMath {
             feeRecipient,
             values,
             fees,
-            expiration,
+            expirationAndSalt[0],
             cancelledValueT,
             orderHash
         );
@@ -265,7 +265,7 @@ contract Exchange is SafeMath {
     /// @param feeRecipient Address that receives order fees.
     /// @param values Array of order valueM and valueT.
     /// @param fees Array of order feeM and feeT.
-    /// @param expiration Time order expires in seconds.
+    /// @param expirationAndSalt Time order expires (seconds since unix epoch) and random number.
     /// @param fillValueT Desired amount of tokenT to fill in order.
     /// @param v ECDSA signature parameter v.
     /// @param rs Array of ECDSA signature parameters r and s.
@@ -276,7 +276,7 @@ contract Exchange is SafeMath {
         address feeRecipient,
         uint[2] values,
         uint[2] fees,
-        uint expiration,
+        uint[2] expirationAndSalt,
         uint fillValueT,
         uint8 v,
         bytes32[2] rs)
@@ -289,7 +289,7 @@ contract Exchange is SafeMath {
             false,
             values,
             fees,
-            expiration,
+            expirationAndSalt,
             fillValueT,
             v,
             rs
@@ -303,7 +303,7 @@ contract Exchange is SafeMath {
     /// @param feeRecipients Array of addresses that receive order fees.
     /// @param values Array of order valueM and valueT tuples.
     /// @param fees Array of order feeM and feeT tuples.
-    /// @param expirations Array of times orders expire in seconds.
+    /// @param expirationsAndSalts Array of times orders expire and random numbers.
     /// @param fillValuesT Array of desired amounts of tokenT to fill in orders.
     /// @param v Array ECDSA signature v parameters.
     /// @param rs Array of ECDSA signature parameters r and s tuples.
@@ -316,7 +316,7 @@ contract Exchange is SafeMath {
         bool shouldCheckTransfer,
         uint[2][] values,
         uint[2][] fees,
-        uint[] expirations,
+        uint[2][] expirationsAndSalts,
         uint[] fillValuesT,
         uint8[] v,
         bytes32[2][] rs)
@@ -330,7 +330,7 @@ contract Exchange is SafeMath {
                 shouldCheckTransfer,
                 values[i],
                 fees[i],
-                expirations[i],
+                expirationsAndSalts[i],
                 fillValuesT[i],
                 v[i],
                 rs[i]
@@ -345,7 +345,7 @@ contract Exchange is SafeMath {
     /// @param feeRecipients Array of addresses that receive order fees.
     /// @param values Array of order valueM and valueT tuples.
     /// @param fees Array of order feeM and feeT tuples.
-    /// @param expirations Array of times orders expire in seconds.
+    /// @param expirationsAndSalts Array of times orders expire and random numbers.
     /// @param fillValuesT Array of desired amounts of tokenT to fill in orders.
     /// @param v Array ECDSA signature v parameters.
     /// @param rs Array of ECDSA signature parameters r and s tuples.
@@ -356,7 +356,7 @@ contract Exchange is SafeMath {
         address[] feeRecipients,
         uint[2][] values,
         uint[2][] fees,
-        uint[] expirations,
+        uint[2][] expirationsAndSalts,
         uint[] fillValuesT,
         uint8[] v,
         bytes32[2][] rs)
@@ -369,7 +369,7 @@ contract Exchange is SafeMath {
                 feeRecipients[i],
                 values[i],
                 fees[i],
-                expirations[i],
+                expirationsAndSalts[i],
                 fillValuesT[i],
                 v[i],
                 rs[i]
@@ -384,7 +384,7 @@ contract Exchange is SafeMath {
     /// @param feeRecipients Array of addresses that receive order fees.
     /// @param values Array of order valueM and valueT tuples.
     /// @param fees Array of order feeM and feeT tuples.
-    /// @param expirations Array of times orders expire in seconds.
+    /// @param expirationsAndSalts Array of times orders expire and random numbers.
     /// @param fillValueT Desired total amount of tokenT to fill in orders.
     /// @param v Array ECDSA signature v parameters.
     /// @param rs Array of ECDSA signature parameters r and s tuples.
@@ -397,7 +397,7 @@ contract Exchange is SafeMath {
         bool shouldCheckTransfer,
         uint[2][] values,
         uint[2][] fees,
-        uint[] expirations,
+        uint[2][] expirationsAndSalts,
         uint fillValueT,
         uint8[] v,
         bytes32[2][] rs)
@@ -413,7 +413,7 @@ contract Exchange is SafeMath {
                 shouldCheckTransfer,
                 values[i],
                 fees[i],
-                expirations[i],
+                expirationsAndSalts[i],
                 safeSub(fillValueT, filledValueT),
                 v[i],
                 rs[i]
@@ -429,7 +429,7 @@ contract Exchange is SafeMath {
     /// @param feeRecipients Array of addresses that receive order fees.
     /// @param values Array of order valueM and valueT tuples.
     /// @param fees Array of order feeM and feeT tuples.
-    /// @param expirations Array of times orders expire in seconds.
+    /// @param expirationsAndSalts Array of times orders expire and random numbers.
     /// @param cancelValuesT Array of desired amounts of tokenT to cancel in orders.
     /// @return Success if no cancels throw.
     function batchCancel(
@@ -438,7 +438,7 @@ contract Exchange is SafeMath {
         address[] feeRecipients,
         uint[2][] values,
         uint[2][] fees,
-        uint[] expirations,
+        uint[2][] expirationsAndSalts,
         uint[] cancelValuesT)
         returns (bool success)
     {
@@ -449,7 +449,7 @@ contract Exchange is SafeMath {
                 feeRecipients[i],
                 values[i],
                 fees[i],
-                expirations[i],
+                expirationsAndSalts[i],
                 cancelValuesT[i]
             );
         }
@@ -466,7 +466,7 @@ contract Exchange is SafeMath {
     /// @param feeRecipient Address that receives order fees.
     /// @param values Array of order valueM and valueT.
     /// @param fees Array of order feeM and feeT.
-    /// @param expiration Time order expires in seconds.
+    /// @param expirationAndSalt Time order expires (seconds since unix epoch) and random number.
     /// @return Keccak-256 hash of order.
     function getOrderHash(
         address[2] traders,
@@ -474,7 +474,7 @@ contract Exchange is SafeMath {
         address feeRecipient,
         uint[2] values,
         uint[2] fees,
-        uint expiration)
+        uint[2] expirationAndSalt)
         constant
         returns (bytes32 orderHash)
     {
@@ -489,7 +489,8 @@ contract Exchange is SafeMath {
             values[1],
             fees[0],
             fees[1],
-            expiration
+            expirationAndSalt[0],
+            expirationAndSalt[1]
         );
     }
 

--- a/util/exchange_wrapper.ts
+++ b/util/exchange_wrapper.ts
@@ -18,7 +18,7 @@ export class ExchangeWrapper {
       params.shouldCheckTransfer,
       params.values,
       params.fees,
-      params.expiration,
+      params.expirationAndSalt,
       params.fillValueT,
       params.v,
       params.rs,
@@ -33,7 +33,7 @@ export class ExchangeWrapper {
       params.feeRecipient,
       params.values,
       params.fees,
-      params.expiration,
+      params.expirationAndSalt,
       params.cancelValueT,
       { from },
     );
@@ -47,7 +47,7 @@ export class ExchangeWrapper {
       params.feeRecipient,
       params.values,
       params.fees,
-      params.expiration,
+      params.expirationAndSalt,
       params.fillValueT,
       params.v,
       params.rs,
@@ -64,7 +64,7 @@ export class ExchangeWrapper {
       params.shouldCheckTransfer,
       params.values,
       params.fees,
-      params.expirations,
+      params.expirationsAndSalts,
       params.fillValuesT,
       params.v,
       params.rs,
@@ -81,7 +81,7 @@ export class ExchangeWrapper {
       params.shouldCheckTransfer,
       params.values,
       params.fees,
-      params.expirations,
+      params.expirationsAndSalts,
       params.fillValueT,
       params.v,
       params.rs,
@@ -96,7 +96,7 @@ export class ExchangeWrapper {
       params.feeRecipients,
       params.values,
       params.fees,
-      params.expirations,
+      params.expirationsAndSalts,
       params.cancelValuesT,
       { from },
     );
@@ -110,7 +110,7 @@ export class ExchangeWrapper {
       params.feeRecipient,
       params.values,
       params.fees,
-      params.expiration,
+      params.expirationAndSalt,
     );
   }
   public isValidSignatureAsync(order: Order) {

--- a/util/formatters.ts
+++ b/util/formatters.ts
@@ -11,7 +11,7 @@ export const formatters = {
       shouldCheckTransfer,
       values: [],
       fees: [],
-      expirations: [],
+      expirationsAndSalts: [],
       fillValuesT,
       v: [],
       rs: [],
@@ -22,7 +22,7 @@ export const formatters = {
       batchFill.feeRecipients.push(order.params.feeRecipient);
       batchFill.values.push([order.params.valueM, order.params.valueT]);
       batchFill.fees.push([order.params.feeM, order.params.feeT]);
-      batchFill.expirations.push(order.params.expiration);
+      batchFill.expirationsAndSalts.push([order.params.expiration, order.params.salt]);
       batchFill.v.push(order.params.v);
       batchFill.rs.push([order.params.r, order.params.s]);
       if (fillValuesT.length < orders.length) {
@@ -39,7 +39,7 @@ export const formatters = {
       shouldCheckTransfer,
       values: [],
       fees: [],
-      expirations: [],
+      expirationsAndSalts: [],
       fillValueT,
       v: [],
       rs: [],
@@ -50,7 +50,7 @@ export const formatters = {
       fillUpTo.feeRecipients.push(order.params.feeRecipient);
       fillUpTo.values.push([order.params.valueM, order.params.valueT]);
       fillUpTo.fees.push([order.params.feeM, order.params.feeT]);
-      fillUpTo.expirations.push(order.params.expiration);
+      fillUpTo.expirationsAndSalts.push([order.params.expiration, order.params.salt]);
       fillUpTo.v.push(order.params.v);
       fillUpTo.rs.push([order.params.r, order.params.s]);
     });
@@ -63,7 +63,7 @@ export const formatters = {
       feeRecipients: [],
       values: [],
       fees: [],
-      expirations: [],
+      expirationsAndSalts: [],
       cancelValuesT,
     };
     orders.forEach(order => {
@@ -72,7 +72,7 @@ export const formatters = {
       batchCancel.feeRecipients.push(order.params.feeRecipient);
       batchCancel.values.push([order.params.valueM, order.params.valueT]);
       batchCancel.fees.push([order.params.feeM, order.params.feeT]);
-      batchCancel.expirations.push(order.params.expiration);
+      batchCancel.expirationsAndSalts.push([order.params.expiration, order.params.salt]);
       if (cancelValuesT.length < orders.length) {
         batchCancel.cancelValuesT.push(order.params.valueT);
       }

--- a/util/order.ts
+++ b/util/order.ts
@@ -49,7 +49,7 @@ export class Order {
       shouldCheckTransfer,
       values: [this.params.valueM, this.params.valueT],
       fees: [this.params.feeM, this.params.feeT],
-      expiration: this.params.expiration,
+      expirationAndSalt: [this.params.expiration, this.params.salt],
       fillValueT: fillValueT || this.params.valueT,
       v: this.params.v,
       rs: [this.params.r, this.params.s],
@@ -63,7 +63,7 @@ export class Order {
       feeRecipient: this.params.feeRecipient,
       values: [this.params.valueM, this.params.valueT],
       fees: [this.params.feeM, this.params.feeT],
-      expiration: this.params.expiration,
+      expirationAndSalt: [this.params.expiration, this.params.salt],
       cancelValueT: cancelValueT || this.params.valueT,
     };
     return cancel;
@@ -81,6 +81,7 @@ export class Order {
       this.params.feeM,
       this.params.feeT,
       this.params.expiration,
+      this.params.salt,
     ]);
     return orderHash;
   }

--- a/util/order_factory.ts
+++ b/util/order_factory.ts
@@ -9,8 +9,10 @@ export class OrderFactory {
   }
   public async newSignedOrderAsync(customOrderParams: OptionalOrderParams = {}) {
     const randomExpiration = Math.floor((Date.now() + (Math.random() * 100000000000)) / 1000);
+    const randomSalt = Math.floor(Math.random() * 100000000000);
     const orderParams = _.assign({}, {
       expiration: randomExpiration,
+      salt: randomSalt,
       taker: '0x0',
     }, this.defaultOrderParams, customOrderParams);
     const order = new Order(orderParams);

--- a/util/types.ts
+++ b/util/types.ts
@@ -11,7 +11,7 @@ export interface BatchFill {
   shouldCheckTransfer: boolean;
   values: string[][];
   fees: string[][];
-  expirations: number[];
+  expirationsAndSalts: number[][];
   fillValuesT: string[];
   v: number[];
   rs: string[][];
@@ -24,7 +24,7 @@ export interface FillUpTo {
   shouldCheckTransfer: boolean;
   values: string[][];
   fees: string[][];
-  expirations: number[];
+  expirationsAndSalts: number[][];
   fillValueT: string;
   v: number[];
   rs: string[][];
@@ -36,7 +36,7 @@ export interface BatchCancel {
   feeRecipients: string[];
   values: string[][];
   fees: string[][];
-  expirations: number[];
+  expirationsAndSalts: number[][];
   cancelValuesT: string[];
 }
 
@@ -78,6 +78,7 @@ export interface OrderParams {
   feeM: string;
   feeT: string;
   expiration: number;
+  salt: number;
   orderHashHex?: string;
   v?: number;
   r?: string;


### PR DESCRIPTION
This PR adds a salt to the order parameters. This is necessary to prevent traders from accidentally creating duplicate orders (with the same `orderHash`).