### PR TITLE
Refactor Exchange params

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -83,7 +83,6 @@ contract Exchange is SafeMath {
         uint feeM;
         uint feeT;
         uint expiration;
-        uint salt;
         bytes32 orderHash;
     }
 
@@ -126,7 +125,6 @@ contract Exchange is SafeMath {
             feeM: orderValues[2],
             feeT: orderValues[3],
             expiration: orderValues[4],
-            salt: orderValues[5],
             orderHash: getOrderHash(orderAddresses, orderValues)
         });
 
@@ -234,7 +232,6 @@ contract Exchange is SafeMath {
             feeM: orderValues[2],
             feeT: orderValues[3],
             expiration: orderValues[4],
-            salt: orderValues[5],
             orderHash: getOrderHash(orderAddresses, orderValues)
         });
 

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -49,7 +49,6 @@ contract Exchange is SafeMath {
         uint feeM,
         uint feeT,
         uint expiration,
-        uint salt,
         uint filledValueT,
         bytes32 indexed tokens,
         bytes32 orderHash
@@ -65,7 +64,6 @@ contract Exchange is SafeMath {
         uint feeM,
         uint feeT,
         uint expiration,
-        uint salt,
         uint cancelledValueT,
         bytes32 indexed tokens,
         bytes32 orderHash
@@ -206,7 +204,6 @@ contract Exchange is SafeMath {
             order.feeM,
             order.feeT,
             order.expiration,
-            order.salt,
             filledValueT,
             sha3(order.tokenM, order.tokenT),
             order.orderHash
@@ -265,7 +262,6 @@ contract Exchange is SafeMath {
             order.feeM,
             order.feeT,
             order.expiration,
-            order.salt,
             cancelledValueT,
             sha3(order.tokenM, order.tokenT),
             order.orderHash

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -36,8 +36,9 @@ contract Exchange is SafeMath {
     address public ZRX;
     address public PROXY;
 
-    mapping (bytes32 => uint) public fills;
-    mapping (bytes32 => uint) public cancels;
+    /// Mappings of orderHash => amounts of valueT filled or cancelled.
+    mapping (bytes32 => uint) public filled;
+    mapping (bytes32 => uint) public cancelled;
 
     event LogFill(
         address indexed maker,
@@ -160,7 +161,7 @@ contract Exchange is SafeMath {
             s
         ));
 
-        fills[order.orderHash] = safeAdd(fills[order.orderHash], filledValueT);
+        filled[order.orderHash] = safeAdd(filled[order.orderHash], filledValueT);
         assert(transferViaProxy(
             order.tokenM,
             order.maker,
@@ -249,7 +250,7 @@ contract Exchange is SafeMath {
             return 0;
         }
 
-        cancels[order.orderHash] = safeAdd(cancels[order.orderHash], cancelledValueT);
+        cancelled[order.orderHash] = safeAdd(cancelled[order.orderHash], cancelledValueT);
 
         LogCancel(
             order.maker,
@@ -516,7 +517,7 @@ contract Exchange is SafeMath {
         constant
         returns (uint unavailableValueT)
     {
-        return safeAdd(fills[orderHash], cancels[orderHash]);
+        return safeAdd(filled[orderHash], cancelled[orderHash]);
     }
 
 

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -159,7 +159,7 @@ contract Exchange is SafeMath {
             order.orderHash,
             v,
             r,
-            r
+            s
         ));
 
         fills[order.orderHash] = safeAdd(fills[order.orderHash], filledValueT);

--- a/contracts/SimpleCrowdsale.sol
+++ b/contracts/SimpleCrowdsale.sol
@@ -76,7 +76,7 @@ contract SimpleCrowdsale is Ownable, SafeMath {
         saleInitialized
         saleNotFinished
     {
-        uint remainingEth = safeSub(order.valueT, exchange.fills(order.orderHash));
+        uint remainingEth = safeSub(order.valueT, exchange.getUnavailableValueT(order.orderHash));
         uint ethToFill = min(msg.value, remainingEth);
         ethToken.deposit.value(ethToFill)();
         assert(exchange.fillOrKill(

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -27,7 +27,7 @@ declare module 'ethereumjs-util' {
   function pubToAddress(pubKey: Buffer, sanitize?: boolean): Buffer;
   function setLength(a: Buffer, length: number): Buffer;
   function setLengthLeft(a: Buffer, length: number): Buffer;
-  function sha3(a: Buffer|String|Number, bits?: number): Buffer;
+  function sha3(a: Buffer|string|number, bits?: number): Buffer;
   function toBuffer(value: any): Buffer;
   function isValidAddress(address: string): boolean;
 

--- a/test/ts/exchange/core.ts
+++ b/test/ts/exchange/core.ts
@@ -88,17 +88,9 @@ contract('Exchange', (accounts: string[]) => {
     ]);
   });
 
-  describe('private functions', () => {
+  describe('internal functions', () => {
     it('should include transferViaProxy', () => {
       assert.equal(exchange.transferViaProxy, undefined);
-    });
-
-    it('should include fillSuccess', () => {
-      assert.equal(exchange.fillSuccess, undefined);
-    });
-
-    it('should include cancelSuccess', () => {
-      assert.equal(exchange.cancelSuccess, undefined);
     });
 
     it('should include isTransferable', () => {

--- a/test/ts/exchange/core.ts
+++ b/test/ts/exchange/core.ts
@@ -118,13 +118,13 @@ contract('Exchange', (accounts: string[]) => {
         valueT: toSmallestUnits(100),
       });
 
-      const filledAmountTBefore = await exchange.fills.call(order.params.orderHashHex);
+      const filledAmountTBefore = await exchange.filled.call(order.params.orderHashHex);
       assert.equal(filledAmountTBefore, 0, 'filledAmountMBefore should be 0');
 
       const fillValueT = order.params.valueT.div(2);
       await exWrapper.fillAsync(order, taker, { fillValueT });
 
-      const filledAmountTAfter = await exchange.fills.call(order.params.orderHashHex);
+      const filledAmountTAfter = await exchange.filled.call(order.params.orderHashHex);
       assert.equal(filledAmountTAfter, fillValueT.toString(), 'filledAmountTAfter should be same as fillValueT');
 
       const newBalances = await dmyBalances.getAsync();
@@ -148,13 +148,13 @@ contract('Exchange', (accounts: string[]) => {
         valueT: toSmallestUnits(100),
       });
 
-      const filledAmountTBefore = await exchange.fills.call(order.params.orderHashHex);
+      const filledAmountTBefore = await exchange.filled.call(order.params.orderHashHex);
       assert.equal(filledAmountTBefore, 0, 'filledAmountTBefore should be 0');
 
       const fillValueT = order.params.valueT.div(2);
       await exWrapper.fillAsync(order, taker, { fillValueT });
 
-      const filledAmountTAfter = await exchange.fills.call(order.params.orderHashHex);
+      const filledAmountTAfter = await exchange.filled.call(order.params.orderHashHex);
       assert.equal(filledAmountTAfter, fillValueT.toString(), 'filledAmountTAfter should be same as fillValueT');
 
       const newBalances = await dmyBalances.getAsync();
@@ -178,13 +178,13 @@ contract('Exchange', (accounts: string[]) => {
         valueT: toSmallestUnits(200),
       });
 
-      const filledAmountTBefore = await exchange.fills.call(order.params.orderHashHex);
+      const filledAmountTBefore = await exchange.filled.call(order.params.orderHashHex);
       assert.equal(filledAmountTBefore, 0, 'filledAmountTBefore should be 0');
 
       const fillValueT = order.params.valueT.div(2);
       await exWrapper.fillAsync(order, taker, { fillValueT });
 
-      const filledAmountTAfter = await exchange.fills.call(order.params.orderHashHex);
+      const filledAmountTAfter = await exchange.filled.call(order.params.orderHashHex);
       assert.equal(filledAmountTAfter, fillValueT.toString(), 'filledAmountTAfter should be same as fillValueT');
 
       const newBalances = await dmyBalances.getAsync();
@@ -209,13 +209,13 @@ contract('Exchange', (accounts: string[]) => {
         valueT: toSmallestUnits(200),
       });
 
-      const filledAmountTBefore = await exchange.fills.call(order.params.orderHashHex);
+      const filledAmountTBefore = await exchange.filled.call(order.params.orderHashHex);
       assert.equal(filledAmountTBefore, 0, 'filledAmountTBefore should be 0');
 
       const fillValueT = order.params.valueT.div(2);
       await exWrapper.fillAsync(order, taker, { fillValueT });
 
-      const filledAmountTAfter = await exchange.fills.call(order.params.orderHashHex);
+      const filledAmountTAfter = await exchange.filled.call(order.params.orderHashHex);
       const expectedFillAmountTAfter = add(fillValueT, filledAmountTBefore);
       assert.equal(filledAmountTAfter.toString(), expectedFillAmountTAfter,
                    'filledAmountTAfter should be same as fillValueT');

--- a/test/ts/simple_crowdsale.ts
+++ b/test/ts/simple_crowdsale.ts
@@ -102,26 +102,14 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
 
   describe('init', () => {
     it('should throw when not called by owner', async () => {
+      const params = order.createFill();
       try {
         await simpleCrowdsale.init(
-          [
-            order.params.maker,
-            order.params.taker,
-            order.params.tokenM,
-            order.params.tokenT,
-            order.params.feeRecipient,
-          ],
-          [
-            order.params.valueM,
-            order.params.valueT,
-            order.params.feeM,
-            order.params.feeT,
-            order.params.expiration,
-            order.params.salt,
-          ],
-          order.params.v,
-          order.params.r,
-          order.params.s,
+          params.orderAddresses,
+          params.orderValues,
+          params.v,
+          params.r,
+          params.s,
           { from: notOwner },
         );
         throw new Error('Init succeeded when it should have thrown');
@@ -132,26 +120,14 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
 
     it('should throw if called with an invalid order signature', async () => {
       try {
+        const params = order.createFill();
         const invalidR = ethUtil.bufferToHex(ethUtil.sha3('invalidR'));
         await simpleCrowdsale.init(
-          [
-            order.params.maker,
-            order.params.taker,
-            order.params.tokenM,
-            order.params.tokenT,
-            order.params.feeRecipient,
-          ],
-          [
-            order.params.valueM,
-            order.params.valueT,
-            order.params.feeM,
-            order.params.feeT,
-            order.params.expiration,
-            order.params.salt,
-          ],
-          order.params.v,
+          params.orderAddresses,
+          params.orderValues,
+          params.v,
           invalidR,
-          order.params.s,
+          params.s,
         );
         throw new Error('Init succeeded when it should have thrown');
       } catch (err) {
@@ -176,27 +152,15 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
       };
       const newOrder = new Order(orderParams);
       await newOrder.signAsync();
+      const params = newOrder.createFill();
 
       try {
         await simpleCrowdsale.init(
-          [
-            newOrder.params.maker,
-            newOrder.params.taker,
-            newOrder.params.tokenM,
-            newOrder.params.tokenT,
-            newOrder.params.feeRecipient,
-          ],
-          [
-            newOrder.params.valueM,
-            newOrder.params.valueT,
-            newOrder.params.feeM,
-            newOrder.params.feeT,
-            newOrder.params.expiration,
-            newOrder.params.salt,
-          ],
-          newOrder.params.v,
-          newOrder.params.r,
-          newOrder.params.s,
+          params.orderAddresses,
+          params.orderValues,
+          params.v,
+          params.r,
+          params.s,
         );
         throw new Error('Init succeeded when it should have thrown');
       } catch (err) {
@@ -221,27 +185,15 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
       };
       const newOrder = new Order(orderParams);
       await newOrder.signAsync();
+      const params = newOrder.createFill();
 
       try {
         await simpleCrowdsale.init(
-          [
-            newOrder.params.maker,
-            newOrder.params.taker,
-            newOrder.params.tokenM,
-            newOrder.params.tokenT,
-            newOrder.params.feeRecipient,
-          ],
-          [
-            newOrder.params.valueM,
-            newOrder.params.valueT,
-            newOrder.params.feeM,
-            newOrder.params.feeT,
-            newOrder.params.expiration,
-            newOrder.params.salt,
-          ],
-          newOrder.params.v,
-          newOrder.params.r,
-          newOrder.params.s,
+          params.orderAddresses,
+          params.orderValues,
+          params.v,
+          params.r,
+          params.s,
         );
         throw new Error('Init succeeded when it should have thrown');
       } catch (err) {
@@ -250,25 +202,13 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
     });
 
     it('should initialize the sale if called by owner with a valid order', async () => {
+      const params = order.createFill();
       await simpleCrowdsale.init(
-        [
-          order.params.maker,
-          order.params.taker,
-          order.params.tokenM,
-          order.params.tokenT,
-          order.params.feeRecipient,
-        ],
-        [
-          order.params.valueM,
-          order.params.valueT,
-          order.params.feeM,
-          order.params.feeT,
-          order.params.expiration,
-          order.params.salt,
-        ],
-        order.params.v,
-        order.params.r,
-        order.params.s,
+        params.orderAddresses,
+        params.orderValues,
+        params.v,
+        params.r,
+        params.s,
         { from: owner },
       );
       const isInitialized = await simpleCrowdsale.isInitialized.call();
@@ -276,26 +216,14 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
     });
 
     it('should throw if the sale has already been initialized', async () => {
+      const params = order.createFill();
       try {
         await simpleCrowdsale.init(
-          [
-            order.params.maker,
-            order.params.taker,
-            order.params.tokenM,
-            order.params.tokenT,
-            order.params.feeRecipient,
-          ],
-          [
-            order.params.valueM,
-            order.params.valueT,
-            order.params.feeM,
-            order.params.feeT,
-            order.params.expiration,
-            order.params.salt,
-          ],
-          order.params.v,
-          order.params.r,
-          order.params.s,
+          params.orderAddresses,
+          params.orderValues,
+          params.v,
+          params.r,
+          params.s,
           { from: owner },
         );
         throw new Error('Init succeeded when it should have thrown');

--- a/test/ts/simple_crowdsale.ts
+++ b/test/ts/simple_crowdsale.ts
@@ -267,7 +267,7 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
     it('should partial fill and end sale if sent ETH > remaining order ETH', async () => {
       const initBalances: BalancesByOwner = await dmyBalances.getAsync();
       const initTakerEthBalance = await getEthBalance(taker);
-      const remainingValueT = sub(order.params.valueT, await exchange.fills.call(order.params.orderHashHex));
+      const remainingValueT = sub(order.params.valueT, await exchange.getUnavailableValueT(order.params.orderHashHex));
 
       const ethValueSent = web3.toWei(20, 'ether');
       const gasPrice = web3.toWei(20, 'gwei');

--- a/test/ts/simple_crowdsale.ts
+++ b/test/ts/simple_crowdsale.ts
@@ -104,14 +104,24 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
     it('should throw when not called by owner', async () => {
       try {
         await simpleCrowdsale.init(
-          [order.params.maker, order.params.taker],
-          [order.params.tokenM, order.params.tokenT],
-          order.params.feeRecipient,
-          [order.params.valueM, order.params.valueT],
-          [order.params.feeM, order.params.feeT],
-          [order.params.expiration, order.params.salt],
+          [
+            order.params.maker,
+            order.params.taker,
+            order.params.tokenM,
+            order.params.tokenT,
+            order.params.feeRecipient,
+          ],
+          [
+            order.params.valueM,
+            order.params.valueT,
+            order.params.feeM,
+            order.params.feeT,
+            order.params.expiration,
+            order.params.salt,
+          ],
           order.params.v,
-          [order.params.r, order.params.s],
+          order.params.r,
+          order.params.s,
           { from: notOwner },
         );
         throw new Error('Init succeeded when it should have thrown');
@@ -124,14 +134,24 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
       try {
         const invalidR = ethUtil.bufferToHex(ethUtil.sha3('invalidR'));
         await simpleCrowdsale.init(
-          [order.params.maker, order.params.taker],
-          [order.params.tokenM, order.params.tokenT],
-          order.params.feeRecipient,
-          [order.params.valueM, order.params.valueT],
-          [order.params.feeM, order.params.feeT],
-          [order.params.expiration, order.params.salt],
+          [
+            order.params.maker,
+            order.params.taker,
+            order.params.tokenM,
+            order.params.tokenT,
+            order.params.feeRecipient,
+          ],
+          [
+            order.params.valueM,
+            order.params.valueT,
+            order.params.feeM,
+            order.params.feeT,
+            order.params.expiration,
+            order.params.salt,
+          ],
           order.params.v,
-          [invalidR, order.params.s],
+          invalidR,
+          order.params.s,
         );
         throw new Error('Init succeeded when it should have thrown');
       } catch (err) {
@@ -159,14 +179,24 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
 
       try {
         await simpleCrowdsale.init(
-          [newOrder.params.maker, newOrder.params.taker],
-          [newOrder.params.tokenM, newOrder.params.tokenT],
-          newOrder.params.feeRecipient,
-          [newOrder.params.valueM, newOrder.params.valueT],
-          [newOrder.params.feeM, newOrder.params.feeT],
-          [newOrder.params.expiration, newOrder.params.salt],
+          [
+            newOrder.params.maker,
+            newOrder.params.taker,
+            newOrder.params.tokenM,
+            newOrder.params.tokenT,
+            newOrder.params.feeRecipient,
+          ],
+          [
+            newOrder.params.valueM,
+            newOrder.params.valueT,
+            newOrder.params.feeM,
+            newOrder.params.feeT,
+            newOrder.params.expiration,
+            newOrder.params.salt,
+          ],
           newOrder.params.v,
-          [newOrder.params.r, newOrder.params.s],
+          newOrder.params.r,
+          newOrder.params.s,
         );
         throw new Error('Init succeeded when it should have thrown');
       } catch (err) {
@@ -194,14 +224,24 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
 
       try {
         await simpleCrowdsale.init(
-          [newOrder.params.maker, newOrder.params.taker],
-          [newOrder.params.tokenM, newOrder.params.tokenT],
-          newOrder.params.feeRecipient,
-          [newOrder.params.valueM, newOrder.params.valueT],
-          [newOrder.params.feeM, newOrder.params.feeT],
-          [newOrder.params.expiration, newOrder.params.salt],
+          [
+            newOrder.params.maker,
+            newOrder.params.taker,
+            newOrder.params.tokenM,
+            newOrder.params.tokenT,
+            newOrder.params.feeRecipient,
+          ],
+          [
+            newOrder.params.valueM,
+            newOrder.params.valueT,
+            newOrder.params.feeM,
+            newOrder.params.feeT,
+            newOrder.params.expiration,
+            newOrder.params.salt,
+          ],
           newOrder.params.v,
-          [newOrder.params.r, newOrder.params.s],
+          newOrder.params.r,
+          newOrder.params.s,
         );
         throw new Error('Init succeeded when it should have thrown');
       } catch (err) {
@@ -211,14 +251,24 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
 
     it('should initialize the sale if called by owner with a valid order', async () => {
       await simpleCrowdsale.init(
-        [order.params.maker, order.params.taker],
-        [order.params.tokenM, order.params.tokenT],
-        order.params.feeRecipient,
-        [order.params.valueM, order.params.valueT],
-        [order.params.feeM, order.params.feeT],
-        [order.params.expiration, order.params.salt],
+        [
+          order.params.maker,
+          order.params.taker,
+          order.params.tokenM,
+          order.params.tokenT,
+          order.params.feeRecipient,
+        ],
+        [
+          order.params.valueM,
+          order.params.valueT,
+          order.params.feeM,
+          order.params.feeT,
+          order.params.expiration,
+          order.params.salt,
+        ],
         order.params.v,
-        [order.params.r, order.params.s],
+        order.params.r,
+        order.params.s,
         { from: owner },
       );
       const isInitialized = await simpleCrowdsale.isInitialized.call();
@@ -228,14 +278,24 @@ contract('SimpleCrowdsale', (accounts: string[]) => {
     it('should throw if the sale has already been initialized', async () => {
       try {
         await simpleCrowdsale.init(
-          [order.params.maker, order.params.taker],
-          [order.params.tokenM, order.params.tokenT],
-          order.params.feeRecipient,
-          [order.params.valueM, order.params.valueT],
-          [order.params.feeM, order.params.feeT],
-          [order.params.expiration, order.params.salt],
+          [
+            order.params.maker,
+            order.params.taker,
+            order.params.tokenM,
+            order.params.tokenT,
+            order.params.feeRecipient,
+          ],
+          [
+            order.params.valueM,
+            order.params.valueT,
+            order.params.feeM,
+            order.params.feeT,
+            order.params.expiration,
+            order.params.salt,
+          ],
           order.params.v,
-          [order.params.r, order.params.s],
+          order.params.r,
+          order.params.s,
           { from: owner },
         );
         throw new Error('Init succeeded when it should have thrown');

--- a/util/exchange_wrapper.ts
+++ b/util/exchange_wrapper.ts
@@ -13,28 +13,21 @@ export class ExchangeWrapper {
     const shouldCheckTransfer = !!opts.shouldCheckTransfer;
     const params = order.createFill(shouldCheckTransfer, opts.fillValueT);
     return this.exchange.fill(
-      params.traders,
-      params.tokens,
-      params.feeRecipient,
-      params.shouldCheckTransfer,
-      params.values,
-      params.fees,
-      params.expirationAndSalt,
+      params.orderAddresses,
+      params.orderValues,
       params.fillValueT,
+      params.shouldCheckTransfer,
       params.v,
-      params.rs,
+      params.r,
+      params.s,
       { from },
     );
   }
   public cancelAsync(order: Order, from: string, opts: { cancelValueT?: BigNumber } = {}) {
     const params = order.createCancel(opts.cancelValueT);
     return this.exchange.cancel(
-      params.traders,
-      params.tokens,
-      params.feeRecipient,
-      params.values,
-      params.fees,
-      params.expirationAndSalt,
+      params.orderAddresses,
+      params.orderValues,
       params.cancelValueT,
       { from },
     );
@@ -43,61 +36,50 @@ export class ExchangeWrapper {
     const shouldCheckTransfer = false;
     const params = order.createFill(shouldCheckTransfer, opts.fillValueT);
     return this.exchange.fillOrKill(
-      params.traders,
-      params.tokens,
-      params.feeRecipient,
-      params.values,
-      params.fees,
-      params.expirationAndSalt,
+      params.orderAddresses,
+      params.orderValues,
       params.fillValueT,
       params.v,
-      params.rs,
+      params.r,
+      params.s,
       { from },
     );
   }
-  public batchFillAsync(orders: Order[], from: string, opts: { fillValuesT?: BigNumber[] } = {}) {
-    const shouldCheckTransfer = false;
+  public batchFillAsync(orders: Order[], from: string,
+                        opts: { fillValuesT?: BigNumber[], shouldCheckTransfer?: boolean } = {}) {
+    const shouldCheckTransfer = !!opts.shouldCheckTransfer;
     const params = formatters.createBatchFill(orders, shouldCheckTransfer, opts.fillValuesT);
     return this.exchange.batchFill(
-      params.traders,
-      params.tokens,
-      params.feeRecipients,
-      params.shouldCheckTransfer,
-      params.values,
-      params.fees,
-      params.expirationsAndSalts,
+      params.orderAddresses,
+      params.orderValues,
       params.fillValuesT,
+      params.shouldCheckTransfer,
       params.v,
-      params.rs,
+      params.r,
+      params.s,
       { from },
     );
   }
-  public fillUpToAsync(orders: Order[], from: string, opts: { fillValueT?: BigNumber } = {}) {
-    const shouldCheckTransfer = false;
+  public fillUpToAsync(orders: Order[], from: string,
+                       opts: { fillValueT?: BigNumber, shouldCheckTransfer?: boolean } = {}) {
+    const shouldCheckTransfer = !!opts.shouldCheckTransfer;
     const params = formatters.createFillUpTo(orders, shouldCheckTransfer, opts.fillValueT);
     return this.exchange.fillUpTo(
-      params.traders,
-      params.tokens,
-      params.feeRecipients,
-      params.shouldCheckTransfer,
-      params.values,
-      params.fees,
-      params.expirationsAndSalts,
+      params.orderAddresses,
+      params.orderValues,
       params.fillValueT,
+      params.shouldCheckTransfer,
       params.v,
-      params.rs,
+      params.r,
+      params.s,
       { from },
     );
   }
   public batchCancelAsync(orders: Order[], from: string, opts: { cancelValuesT?: BigNumber[] } = {}) {
     const params = formatters.createBatchCancel(orders, opts.cancelValuesT);
     return this.exchange.batchCancel(
-      params.traders,
-      params.tokens,
-      params.feeRecipients,
-      params.values,
-      params.fees,
-      params.expirationsAndSalts,
+      params.orderAddresses,
+      params.orderValues,
       params.cancelValuesT,
       { from },
     );
@@ -105,14 +87,7 @@ export class ExchangeWrapper {
   public getOrderHashAsync(order: Order) {
     const shouldCheckTransfer = false;
     const params = order.createFill(shouldCheckTransfer);
-    return this.exchange.getOrderHash(
-      params.traders,
-      params.tokens,
-      params.feeRecipient,
-      params.values,
-      params.fees,
-      params.expirationAndSalt,
-    );
+    return this.exchange.getOrderHash(params.orderAddresses, params.orderValues);
   }
   public isValidSignatureAsync(order: Order) {
     const isValidSignature = this.exchange.isValidSignature(

--- a/util/formatters.ts
+++ b/util/formatters.ts
@@ -6,26 +6,22 @@ import BigNumber = require('bignumber.js');
 export const formatters = {
   createBatchFill(orders: Order[], shouldCheckTransfer: boolean, fillValuesT: BigNumber[] = []) {
     const batchFill: BatchFill = {
-      traders: [],
-      tokens: [],
-      feeRecipients: [],
-      shouldCheckTransfer,
-      values: [],
-      fees: [],
-      expirationsAndSalts: [],
+      orderAddresses: [],
+      orderValues: [],
       fillValuesT,
+      shouldCheckTransfer,
       v: [],
-      rs: [],
+      r: [],
+      s: [],
     };
     _.forEach(orders, order => {
-      batchFill.traders.push([order.params.maker, order.params.taker]);
-      batchFill.tokens.push([order.params.tokenM, order.params.tokenT]);
-      batchFill.feeRecipients.push(order.params.feeRecipient);
-      batchFill.values.push([order.params.valueM, order.params.valueT]);
-      batchFill.fees.push([order.params.feeM, order.params.feeT]);
-      batchFill.expirationsAndSalts.push([order.params.expiration, order.params.salt]);
+      batchFill.orderAddresses.push([order.params.maker, order.params.taker, order.params.tokenM,
+                                     order.params.tokenT, order.params.feeRecipient]);
+      batchFill.orderValues.push([order.params.valueM, order.params.valueT, order.params.feeM,
+                                  order.params.feeT, order.params.expiration, order.params.salt]);
       batchFill.v.push(order.params.v);
-      batchFill.rs.push([order.params.r, order.params.s]);
+      batchFill.r.push(order.params.r);
+      batchFill.s.push(order.params.s);
       if (fillValuesT.length < orders.length) {
         batchFill.fillValuesT.push(order.params.valueT);
       }
@@ -34,46 +30,36 @@ export const formatters = {
   },
   createFillUpTo(orders: Order[], shouldCheckTransfer: boolean, fillValueT: BigNumber) {
     const fillUpTo: FillUpTo = {
-      traders: [],
-      tokens: [],
-      feeRecipients: [],
-      shouldCheckTransfer,
-      values: [],
-      fees: [],
-      expirationsAndSalts: [],
+      orderAddresses: [],
+      orderValues: [],
       fillValueT,
+      shouldCheckTransfer,
       v: [],
-      rs: [],
+      r: [],
+      s: [],
     };
     orders.forEach(order => {
-      fillUpTo.traders.push([order.params.maker, order.params.taker]);
-      fillUpTo.tokens.push([order.params.tokenM, order.params.tokenT]);
-      fillUpTo.feeRecipients.push(order.params.feeRecipient);
-      fillUpTo.values.push([order.params.valueM, order.params.valueT]);
-      fillUpTo.fees.push([order.params.feeM, order.params.feeT]);
-      fillUpTo.expirationsAndSalts.push([order.params.expiration, order.params.salt]);
+      fillUpTo.orderAddresses.push([order.params.maker, order.params.taker, order.params.tokenM,
+                                    order.params.tokenT, order.params.feeRecipient]);
+      fillUpTo.orderValues.push([order.params.valueM, order.params.valueT, order.params.feeM,
+                                 order.params.feeT, order.params.expiration, order.params.salt]);
       fillUpTo.v.push(order.params.v);
-      fillUpTo.rs.push([order.params.r, order.params.s]);
+      fillUpTo.r.push(order.params.r);
+      fillUpTo.s.push(order.params.s);
     });
     return fillUpTo;
   },
   createBatchCancel(orders: Order[], cancelValuesT: BigNumber[] = []) {
     const batchCancel: BatchCancel = {
-      traders: [],
-      tokens: [],
-      feeRecipients: [],
-      values: [],
-      fees: [],
-      expirationsAndSalts: [],
+      orderAddresses: [],
+      orderValues: [],
       cancelValuesT,
     };
     orders.forEach(order => {
-      batchCancel.traders.push([order.params.maker, order.params.taker]);
-      batchCancel.tokens.push([order.params.tokenM, order.params.tokenT]);
-      batchCancel.feeRecipients.push(order.params.feeRecipient);
-      batchCancel.values.push([order.params.valueM, order.params.valueT]);
-      batchCancel.fees.push([order.params.feeM, order.params.feeT]);
-      batchCancel.expirationsAndSalts.push([order.params.expiration, order.params.salt]);
+      batchCancel.orderAddresses.push([order.params.maker, order.params.taker, order.params.tokenM,
+                                       order.params.tokenT, order.params.feeRecipient]);
+      batchCancel.orderValues.push([order.params.valueM, order.params.valueT, order.params.feeM,
+                                    order.params.feeT, order.params.expiration, order.params.salt]);
       if (cancelValuesT.length < orders.length) {
         batchCancel.cancelValuesT.push(order.params.valueT);
       }

--- a/util/order.ts
+++ b/util/order.ts
@@ -42,7 +42,7 @@ export class Order {
       s: ethUtil.bufferToHex(s),
     });
   }
-  public createFill(shouldCheckTransfer: boolean, fillValueT?: BigNumber) {
+  public createFill(shouldCheckTransfer?: boolean, fillValueT?: BigNumber) {
     const fill = {
       orderAddresses: [
         this.params.maker,
@@ -60,7 +60,7 @@ export class Order {
         this.params.salt,
       ],
       fillValueT: fillValueT || this.params.valueT,
-      shouldCheckTransfer,
+      shouldCheckTransfer: !!shouldCheckTransfer,
       v: this.params.v,
       r: this.params.r,
       s: this.params.s,

--- a/util/order.ts
+++ b/util/order.ts
@@ -44,27 +44,46 @@ export class Order {
   }
   public createFill(shouldCheckTransfer: boolean, fillValueT?: BigNumber) {
     const fill = {
-      traders: [this.params.maker, this.params.taker],
-      tokens: [this.params.tokenM, this.params.tokenT],
-      feeRecipient: this.params.feeRecipient,
-      shouldCheckTransfer,
-      values: [this.params.valueM, this.params.valueT],
-      fees: [this.params.feeM, this.params.feeT],
-      expirationAndSalt: [this.params.expiration, this.params.salt],
+      orderAddresses: [
+        this.params.maker,
+        this.params.taker,
+        this.params.tokenM,
+        this.params.tokenT,
+        this.params.feeRecipient,
+      ],
+      orderValues: [
+        this.params.valueM,
+        this.params.valueT,
+        this.params.feeM,
+        this.params.feeT,
+        this.params.expiration,
+        this.params.salt,
+      ],
       fillValueT: fillValueT || this.params.valueT,
+      shouldCheckTransfer,
       v: this.params.v,
-      rs: [this.params.r, this.params.s],
+      r: this.params.r,
+      s: this.params.s,
     };
     return fill;
   }
   public createCancel(cancelValueT?: BigNumber) {
     const cancel = {
-      traders: [this.params.maker, this.params.taker],
-      tokens: [this.params.tokenM, this.params.tokenT],
-      feeRecipient: this.params.feeRecipient,
-      values: [this.params.valueM, this.params.valueT],
-      fees: [this.params.feeM, this.params.feeT],
-      expirationAndSalt: [this.params.expiration, this.params.salt],
+      orderAddresses: [
+        this.params.maker,
+        this.params.taker,
+        this.params.tokenM,
+        this.params.tokenT,
+        this.params.feeRecipient,
+      ],
+      orderValues: [
+        this.params.valueM,
+        this.params.valueT,
+        this.params.feeM,
+        this.params.feeT,
+        this.params.expiration,
+        this.params.salt,
+      ],
       cancelValueT: cancelValueT || this.params.valueT,
     };
     return cancel;

--- a/util/types.ts
+++ b/util/types.ts
@@ -7,38 +7,28 @@ export interface BalancesByOwner {
 }
 
 export interface BatchFill {
-  traders: string[][];
-  tokens: string[][];
-  feeRecipients: string[];
-  shouldCheckTransfer: boolean;
-  values: BigNumber[][];
-  fees: BigNumber[][];
-  expirationsAndSalts: BigNumber[][];
+  orderAddresses: string[][];
+  orderValues: BigNumber[][];
   fillValuesT: BigNumber[];
+  shouldCheckTransfer: boolean;
   v: number[];
-  rs: string[][];
+  r: string[];
+  s: string[];
 }
 
 export interface FillUpTo {
-  traders: string[][];
-  tokens: string[][];
-  feeRecipients: string[];
-  shouldCheckTransfer: boolean;
-  values: BigNumber[][];
-  fees: BigNumber[][];
-  expirationsAndSalts: BigNumber[][];
+  orderAddresses: string[][];
+  orderValues: BigNumber[][];
   fillValueT: BigNumber;
+  shouldCheckTransfer: boolean;
   v: number[];
-  rs: string[][];
+  r: string[];
+  s: string[];
 }
 
 export interface BatchCancel {
-  traders: string[][];
-  tokens: string[][];
-  feeRecipients: string[];
-  values: BigNumber[][];
-  fees: BigNumber[][];
-  expirationsAndSalts: BigNumber[][];
+  orderAddresses: string[][];
+  orderValues: BigNumber[][];
   cancelValuesT: BigNumber[];
 }
 


### PR DESCRIPTION
This PR:

-Adds an `Order` struct to the `Exchange` contract.
-Removes all of the tuple params from all of the `Exchange` methods in favor of `orderAddresses` and `orderValues` arrays.

With the above changes, we free up local variable slots (we were previously at the max) and increase code readability. The new local variable slots allow us to make the below changes:

-Remove `fillSuccess` and `cancelSuccess`.
-The `rs` param has been separated into `r` and `s` (I could still see this going either way).
-Filled and cancelled amounts are now stored in two separate mappings, `filled` and `cancelled`. It could be useful to have on-chain proof that specific orders were either filled or cancelled, where it was previously impossible to differentiate. A helper method `getUnavailableValueT` has also been added, which returns the sum of `filled[orderHash]` and `cancelled[orderHash]`.

Other minor changes:
-Private methods are now internal.