### PR TITLE
Update token sale

### DIFF
--- a/contracts/TokenSaleWithRegistry.sol
+++ b/contracts/TokenSaleWithRegistry.sol
@@ -54,7 +54,7 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
     }
 
     modifier saleStarted() {
-        assert(startTimeInSec != 0 && block.timestamp >= startTimeInSec);
+        assert(isSaleInitialized && block.timestamp >= startTimeInSec);
         _;
     }
 
@@ -221,12 +221,14 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
     }
 
     /// @dev Calculates the ETH cap per address. The cap increases by double the previous increase at each next period. E.g 1, 3, 7, 15
-    /// @return THe current ETH cap per address.
+    /// @return The current ETH cap per address.
     function getEthCapPerAddress()
         public
         constant
-        returns (uint ethCapPerAddress)
+        returns (uint)
     {
+        if (block.timestamp < startTimeInSec || startTimeInSec == 0) return 0;
+
         uint timeSinceStartInSec = safeSub(block.timestamp, startTimeInSec);
         uint currentPeriod = safeAdd(                           // currentPeriod begins at 1
               safeDiv(timeSinceStartInSec, TIME_PERIOD_IN_SEC), // rounds down
@@ -237,7 +239,7 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
             baseEthCapPerAddress,
             safeSub(
                 2 ** currentPeriod,
-                currentPeriod
+                1
             )
         );
     }

--- a/contracts/TokenSaleWithRegistry.sol
+++ b/contracts/TokenSaleWithRegistry.sol
@@ -13,7 +13,6 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
 
     uint public constant TIME_PERIOD_IN_SEC = 1 days;
 
-    address public PROXY_CONTRACT;
     address public EXCHANGE_CONTRACT;
     address public PROTOCOL_TOKEN_CONTRACT;
     address public ETH_TOKEN_CONTRACT;
@@ -81,11 +80,9 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
 
     function TokenSaleWithRegistry(
         address _exchange,
-        address _proxy,
         address _protocolToken,
         address _ethToken)
     {
-        PROXY_CONTRACT = _proxy;
         EXCHANGE_CONTRACT = _exchange;
         PROTOCOL_TOKEN_CONTRACT = _protocolToken;
         ETH_TOKEN_CONTRACT = _ethToken;
@@ -155,7 +152,7 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
             s
         ));
 
-        assert(Token(ETH_TOKEN_CONTRACT).approve(PROXY_CONTRACT, order.takerTokenAmount));
+        assert(ethToken.approve(exchange.PROXY_CONTRACT(), order.takerTokenAmount));
         isSaleInitialized = true;
         startTimeInSec = _startTimeInSec;
         baseEthCapPerAddress = _baseEthCapPerAddress;

--- a/contracts/TokenSaleWithRegistry.sol
+++ b/contracts/TokenSaleWithRegistry.sol
@@ -193,6 +193,7 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
         if (remainingEth == ethToFill) {
             isSaleFinished = true;
             SaleFinished(block.timestamp);
+            return;
         }
     }
 
@@ -235,13 +236,14 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
               1
         );
 
-        return safeMul(
+        uint ethCapPerAddress = safeMul(
             baseEthCapPerAddress,
             safeSub(
                 2 ** currentPeriod,
                 1
             )
         );
+        return ethCapPerAddress;
     }
 
     /// @dev Calculates Keccak-256 hash of order with specified parameters.

--- a/test/ts/token_sale_with_registry.ts
+++ b/test/ts/token_sale_with_registry.ts
@@ -646,6 +646,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
         const finalBalances: BalancesByOwner = await dmyBalances.getAsync();
         const finalTakerEthBalance = await getEthBalanceAsync(taker);
         const ethSpentOnGas = mul(res.receipt.gasUsed, gasPrice);
+        const remainingTakerBalanceAfterFillAndGas = sub(sub(initTakerEthBalance, ethValue), ethSpentOnGas);
 
         assert.equal(finalBalances[maker][validOrder.params.makerToken],
                      sub(initBalances[maker][validOrder.params.makerToken], zrxValue));
@@ -653,7 +654,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
                      add(initBalances[maker][validOrder.params.takerToken], ethValue));
         assert.equal(finalBalances[taker][validOrder.params.makerToken],
                      add(initBalances[taker][validOrder.params.makerToken], zrxValue));
-        assert.equal(finalTakerEthBalance, sub(sub(initTakerEthBalance, ethValue), ethSpentOnGas));
+        assert.equal(finalTakerEthBalance, remainingTakerBalanceAfterFillAndGas);
       });
 
       it('should fill the remaining ethCapPerAddress and refund difference if sent > than the remaining ethCapPerAddress',
@@ -686,6 +687,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
         const ethSpentOnGas = mul(res.receipt.gasUsed, gasPrice);
         const filledZrxValue = baseEthCapPerAddress;
         const filledEthValue = baseEthCapPerAddress;
+        const remainingTakerBalanceAfterFillAndGas = sub(sub(initTakerEthBalance, filledEthValue), ethSpentOnGas);
 
         assert.equal(finalBalances[maker][validOrder.params.makerToken],
                      sub(initBalances[maker][validOrder.params.makerToken], filledZrxValue));
@@ -693,7 +695,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
                      add(initBalances[maker][validOrder.params.takerToken], filledEthValue));
         assert.equal(finalBalances[taker][validOrder.params.makerToken],
                      add(initBalances[taker][validOrder.params.makerToken], filledZrxValue));
-        assert.equal(finalTakerEthBalance, sub(sub(initTakerEthBalance, filledEthValue), ethSpentOnGas));
+        assert.equal(finalTakerEthBalance, remainingTakerBalanceAfterFillAndGas);
       });
 
       it('should partial fill, end sale, and refund difference if sender is registered and sent ETH > remaining order ETH', async () => {
@@ -726,6 +728,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
         const ethSpentOnGas = mul(res.receipt.gasUsed, gasPrice);
         const filledZrxValue = validOrder.params.makerTokenAmount;
         const filledEthValue = validOrder.params.takerTokenAmount;
+        const remainingTakerBalanceAfterFillAndGas = sub(sub(initTakerEthBalance, filledEthValue), ethSpentOnGas);
 
         assert.equal(finalBalances[maker][validOrder.params.makerToken],
                      sub(initBalances[maker][validOrder.params.makerToken], filledZrxValue));
@@ -733,7 +736,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
                      add(initBalances[maker][validOrder.params.takerToken], filledEthValue));
         assert.equal(finalBalances[taker][validOrder.params.makerToken],
                      add(initBalances[taker][validOrder.params.makerToken], filledZrxValue));
-        assert.equal(finalTakerEthBalance, sub(sub(initTakerEthBalance, filledEthValue), ethSpentOnGas));
+        assert.equal(finalTakerEthBalance, remainingTakerBalanceAfterFillAndGas);
 
         assert.equal(res.receipt.logs.length, 5, 'Expected 5 events to fire when the sale is successfully initialized');
         const finishedLog = res.receipt.logs[4];
@@ -775,6 +778,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
         let totalEthSpentOnGas = mul(res.receipt.gasUsed, gasPrice);
         let totalFilledZrxValue = ethValue;
         let totalFilledEthValue = ethValue;
+        let remainingTakerBalanceAfterFillAndGas = sub(sub(initTakerEthBalance, totalFilledEthValue), totalEthSpentOnGas);
 
         assert.equal(finalBalances[maker][validOrder.params.makerToken],
                      sub(initBalances[maker][validOrder.params.makerToken], totalFilledZrxValue));
@@ -782,7 +786,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
                      add(initBalances[maker][validOrder.params.takerToken], totalFilledEthValue));
         assert.equal(finalBalances[taker][validOrder.params.makerToken],
                      add(initBalances[taker][validOrder.params.makerToken], totalFilledZrxValue));
-        assert.equal(finalTakerEthBalance, sub(sub(initTakerEthBalance, totalFilledEthValue), totalEthSpentOnGas));
+        assert.equal(finalTakerEthBalance, remainingTakerBalanceAfterFillAndGas);
 
         await rpc.increaseTimeAsync(timePeriodInSec);
         period += 1;
@@ -799,6 +803,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
         totalEthSpentOnGas = add(totalEthSpentOnGas, mul(res.receipt.gasUsed, gasPrice));
         totalFilledZrxValue = totalEthValue;
         totalFilledEthValue = totalEthValue;
+        remainingTakerBalanceAfterFillAndGas = sub(sub(initTakerEthBalance, totalFilledEthValue), totalEthSpentOnGas);
 
         assert.equal(finalBalances[maker][validOrder.params.makerToken],
                      sub(initBalances[maker][validOrder.params.makerToken], totalFilledZrxValue));
@@ -806,7 +811,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
                      add(initBalances[maker][validOrder.params.takerToken], totalFilledEthValue));
         assert.equal(finalBalances[taker][validOrder.params.makerToken],
                      add(initBalances[taker][validOrder.params.makerToken], totalFilledZrxValue));
-        assert.equal(finalTakerEthBalance, sub(sub(initTakerEthBalance, totalFilledEthValue), totalEthSpentOnGas));
+        assert.equal(finalTakerEthBalance, remainingTakerBalanceAfterFillAndGas);
 
         await rpc.increaseTimeAsync(timePeriodInSec);
         period += 1;
@@ -823,6 +828,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
         totalEthSpentOnGas = add(totalEthSpentOnGas, mul(res.receipt.gasUsed, gasPrice));
         totalFilledZrxValue = totalEthValue;
         totalFilledEthValue = totalEthValue;
+        remainingTakerBalanceAfterFillAndGas = sub(sub(initTakerEthBalance, totalFilledEthValue), totalEthSpentOnGas);
 
         assert.equal(finalBalances[maker][validOrder.params.makerToken],
                      sub(initBalances[maker][validOrder.params.makerToken], totalFilledZrxValue));
@@ -830,7 +836,7 @@ contract('TokenSaleWithRegistry', (accounts: string[]) => {
                      add(initBalances[maker][validOrder.params.takerToken], totalFilledEthValue));
         assert.equal(finalBalances[taker][validOrder.params.makerToken],
                      add(initBalances[taker][validOrder.params.makerToken], totalFilledZrxValue));
-        assert.equal(finalTakerEthBalance, sub(sub(initTakerEthBalance, totalFilledEthValue), totalEthSpentOnGas));
+        assert.equal(finalTakerEthBalance, remainingTakerBalanceAfterFillAndGas);
       });
 
       it('should throw if sale has ended', async () => {

--- a/util/rpc.ts
+++ b/util/rpc.ts
@@ -16,6 +16,11 @@ export class RPC {
     const payload = this.toPayload(method, params);
     return this.sendAsync(payload);
   }
+  public async mineBlockAsync() {
+    const method = 'evm_mine';
+    const payload = this.toPayload(method);
+    return this.sendAsync(payload);
+  }
   private toPayload(method: string, params: any[] = []) {
     const payload = JSON.stringify({
       id: this.id,


### PR DESCRIPTION
- Make naming more explicit
- Add check to make sure order feeRecipient is null
- `initializeSale` now sets a `baseEthCapPerAddress` and the timestamp where the order becomes fillable
- Remove `setCapPerAddress`. The cap now increases automatically every 24 hours, with the increase being equal to double the previous increase (1, 3, 7, 15...)
- Fixes issue #100 