### PR TITLE
Update ZRX

### DIFF
--- a/contracts/tokens/ZRXToken.sol
+++ b/contracts/tokens/ZRXToken.sol
@@ -3,14 +3,55 @@ pragma solidity ^0.4.11;
 import "./../base/StandardToken.sol";
 
 contract ZRXToken is StandardToken {
-  
+
     uint8 constant public decimals = 18;
+    uint public totalSupply = 10**27; // 1 billion tokens, 18 decimal places
     string constant public name = "0x Protocol Token";
     string constant public symbol = "ZRX";
 
+    mapping(address => mapping(address => bool)) allowedUnlimited;
+
+    event UnlimitedApproval(address indexed _owner, address indexed _spender, bool _approval);
+
     function ZRXToken() {
-        totalSupply = 10**27; // 1 billion tokens, 18 decimal places
         balances[msg.sender] = totalSupply;
     }
 
+    function approveUnlimited(address _spender, bool _approval)
+        public
+        returns (bool)
+    {
+        allowedUnlimited[msg.sender][_spender] = _approval;
+        UnlimitedApproval(msg.sender, _spender, _approval);
+        return true;
+    }
+
+    function transferFrom(address _from, address _to, uint _value)
+        public
+        returns (bool)
+    {
+        bool isAllowedUnlimited = allowedUnlimited[_from][msg.sender];
+        if (   balances[_from] >= _value
+            && (isAllowedUnlimited || allowed[_from][msg.sender] >= _value)
+            && balances[_to] + _value >= balances[_to]
+        ) {
+            balances[_to] += _value;
+            balances[_from] -= _value;
+            if (!isAllowedUnlimited) {
+                allowed[_from][msg.sender] -= _value;
+            }
+            Transfer(_from, _to, _value);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    function unlimitedAllowance(address _owner, address _spender)
+        public
+        constant
+        returns (bool)
+    {
+        return allowedUnlimited[_owner][_spender];
+    }
 }

--- a/contracts/tokens/ZRXToken.sol
+++ b/contracts/tokens/ZRXToken.sol
@@ -30,14 +30,14 @@ contract ZRXToken is StandardToken {
         public
         returns (bool)
     {
-        bool isAllowedUnlimited = allowedUnlimited[_from][msg.sender];
-        if (   balances[_from] >= _value
-            && (isAllowedUnlimited || allowed[_from][msg.sender] >= _value)
+        bool hasUnlimitedAllowance = allowedUnlimited[_from][msg.sender];
+        if (balances[_from] >= _value
+            && (hasUnlimitedAllowance || allowed[_from][msg.sender] >= _value)
             && balances[_to] + _value >= balances[_to]
         ) {
             balances[_to] += _value;
             balances[_from] -= _value;
-            if (!isAllowedUnlimited) {
+            if (!hasUnlimitedAllowance) {
                 allowed[_from][msg.sender] -= _value;
             }
             Transfer(_from, _to, _value);

--- a/test/ts/zrxToken.ts
+++ b/test/ts/zrxToken.ts
@@ -1,0 +1,173 @@
+import * as assert from 'assert';
+import * as Web3 from 'web3';
+import * as BigNumber from 'bignumber.js';
+import { testUtil } from '../../util/test_util';
+import { Artifacts } from '../../util/artifacts';
+import { ContractInstance } from '../../util/types';
+
+const { ZRXToken } = new Artifacts(artifacts);
+const web3Instance: Web3 = web3;
+
+contract('ZRXToken', (accounts: string[]) => {
+  const owner = accounts[0];
+  const spender = accounts[1];
+
+  let zrx: ContractInstance;
+
+  beforeEach(async () => {
+    zrx = await ZRXToken.new({ from: owner });
+  });
+
+  describe('constants', () => {
+    it('should have 18 decimals', async () => {
+      const decimals = await zrx.decimals.call();
+      const expectedDecimals = '18';
+      assert.equal(decimals.toString(), expectedDecimals);
+    });
+
+    it('should have a total supply of 1 billion tokens', async () => {
+      const totalSupply = await zrx.totalSupply.call();
+      const expectedTotalSupply = '1000000000';
+      assert.equal(web3Instance.fromWei(totalSupply, 'ether').toString(), expectedTotalSupply.toString());
+    });
+
+    it('should be named 0x Protocol Token', async () => {
+      const name = await zrx.name.call();
+      const expectedName = '0x Protocol Token';
+      assert.equal(name, expectedName);
+    });
+
+    it('should have the symbol ZRX', async () => {
+      const symbol = await zrx.symbol.call();
+      const expectedSymbol = 'ZRX';
+      assert.equal(symbol, expectedSymbol);
+    });
+  });
+
+  describe('constructor', () => {
+    it('should initialize owner balance to totalSupply', async () => {
+      const ownerBalance = await zrx.balanceOf(owner);
+      const totalSupply = await zrx.totalSupply.call();
+      assert.equal(totalSupply.toString(), ownerBalance.toString());
+    });
+  });
+
+  describe('transfer', () => {
+    it('should transfer balance from sender to receiver', async () => {
+      const initOwnerBalance = await zrx.balanceOf(owner);
+      const amountToTransfer = new BigNumber(1);
+      await zrx.transfer(spender, amountToTransfer, { from: owner });
+      const finalOwnerBalance = await zrx.balanceOf(owner);
+      const finalSpenderBalance = await zrx.balanceOf(spender);
+
+      const expectedFinalOwnerBalance = initOwnerBalance.minus(amountToTransfer);
+      const expectedFinalSpenderBalance = amountToTransfer;
+      assert.equal(finalOwnerBalance.toString(), expectedFinalOwnerBalance.toString());
+      assert.equal(finalSpenderBalance.toString(), expectedFinalSpenderBalance.toString());
+    });
+
+    it('should return true on a 0 value transfer', async () => {
+      const didReturnTrue = await zrx.transfer.call(spender, 0, { from: owner });
+      assert.equal(didReturnTrue, true);
+    });
+  });
+
+  describe('approveUnlimited', () => {
+    it('should log an event with the correct args', async () => {
+      const approval = true;
+      const res = await zrx.approveUnlimited(spender, approval, { from: owner });
+      const logs = res.logs;
+      assert.equal(logs.length, 1);
+
+      const logArgs = logs[0].args;
+      assert.equal(logArgs._owner, owner);
+      assert.equal(logArgs._spender, spender);
+      assert.equal(logArgs._approval, approval);
+    });
+
+    it('should update the allowedUnlimited mapping with the correct approval', async () => {
+      let approval = true;
+      await zrx.approveUnlimited(spender, approval);
+      let isApproved = await zrx.unlimitedAllowance(owner, spender);
+      assert.equal(isApproved, approval);
+
+      approval = false;
+      await zrx.approveUnlimited(spender, approval);
+      isApproved = await zrx.unlimitedAllowance(owner, spender);
+      assert.equal(isApproved, approval);
+    });
+  });
+
+  describe('transferFrom', () => {
+    it('should return false if owner has insufficient balance', async () => {
+      const ownerBalance = await zrx.balanceOf(owner);
+      const amountToTransfer = ownerBalance.plus(1);
+      await zrx.approve(spender, amountToTransfer, { from: owner });
+      const didReturnTrue = await zrx.transferFrom.call(owner, spender, amountToTransfer, { from: spender });
+      assert.equal(didReturnTrue, false);
+    });
+
+    it('should return false if spender is not allowed unlimited and owner has insufficient allowance', async () => {
+      const ownerBalance = await zrx.balanceOf(owner);
+      const amountToTransfer = ownerBalance;
+      const didReturnTrue = await zrx.transferFrom.call(owner, spender, amountToTransfer, { from: spender });
+      assert.equal(didReturnTrue, false);
+    });
+
+    it('should return true on a 0 value transfer', async () => {
+      const amountToTransfer = 0;
+      const didReturnTrue = await zrx.transferFrom.call(owner, spender, amountToTransfer, { from: spender });
+      assert.equal(didReturnTrue, true);
+    });
+
+    it('should transfer the correct balances if spender is allowed unlimited', async () => {
+      const initOwnerBalance = await zrx.balanceOf(owner);
+      const amountToTransfer = initOwnerBalance;
+      await zrx.approveUnlimited(spender, true, { from: owner });
+      await zrx.transferFrom(owner, spender, amountToTransfer, { from: spender });
+
+      const newOwnerBalance = await zrx.balanceOf(owner);
+      const newSpenderBalance = await zrx.balanceOf(spender);
+
+      assert.equal(newOwnerBalance.toString(), '0');
+      assert.equal(newSpenderBalance.toString(), initOwnerBalance.toString());
+    });
+
+    it('should not modify spender allowance if spender is allowed unlimited', async () => {
+      const initOwnerBalance = await zrx.balanceOf(owner);
+      const amountToTransfer = initOwnerBalance;
+      const initSpenderAllowance = initOwnerBalance;
+      await zrx.approveUnlimited(spender, true, { from: owner });
+      await zrx.approve(spender, initSpenderAllowance, { from: owner });
+      await zrx.transferFrom(owner, spender, amountToTransfer, { from: spender });
+
+      const newSpenderAllowance = await zrx.allowance(owner, spender);
+      assert.equal(initSpenderAllowance.toString(), newSpenderAllowance.toString());
+    });
+
+    it('should transfer the correct balances if spender is not allowed unlimited but has sufficient allowance', async () => {
+      const initOwnerBalance = await zrx.balanceOf(owner);
+      const amountToTransfer = initOwnerBalance;
+      const initSpenderAllowance = initOwnerBalance;
+      await zrx.approve(spender, initSpenderAllowance, { from: owner });
+      await zrx.transferFrom(owner, spender, amountToTransfer, { from: spender });
+
+      const newOwnerBalance = await zrx.balanceOf(owner);
+      const newSpenderBalance = await zrx.balanceOf(spender);
+
+      assert.equal(newOwnerBalance.toString(), '0');
+      assert.equal(newSpenderBalance.toString(), initOwnerBalance.toString());
+    });
+
+    it('should modify allowance if spender is not allowed unlimited but has sufficient allowance', async () => {
+      const initOwnerBalance = await zrx.balanceOf(owner);
+      const amountToTransfer = initOwnerBalance;
+      const initSpenderAllowance = initOwnerBalance;
+      await zrx.approve(spender, initSpenderAllowance, { from: owner });
+      await zrx.transferFrom(owner, spender, amountToTransfer, { from: spender });
+
+      const newSpenderAllowance = await zrx.allowance(owner, spender);
+      assert.equal(newSpenderAllowance, '0');
+    });
+  });
+});


### PR DESCRIPTION
- Add `allowedUnlimited` mapping that maps owner => spender => bool
- Add `approveUnlimited` and `unlimitedAllowance` functions. This allows a token owner to provide an address with an unlimited allowance (ONLY DO THIS FOR CONTRACTS THAT YOU TRUST 100%). When tokens are frequently being transferred via `transferFrom` (as they are in the 0x contracts), this has significant gas savings in the long run, since the `allowed` mapping does not need to be updated for each transfer (~5k per transfer).
- `transferFrom` first checks the `allowedUnlimited` mapping, then falls back to `allowed`.
- Adds an `UnlimitedApproval` event
- Adds tests for new functionality and standard token basic functionality