### PR TITLE
MultiSig bytes4FromBytes

### DIFF
--- a/contracts/MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress.sol
+++ b/contracts/MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress.sol
@@ -57,13 +57,13 @@ contract MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress is MultiSigWall
         returns (bytes4)
     {
         require(data.length >= 4);
-        
+
         bytes4 first4Bytes;
-        
+
         assembly {
             first4Bytes := mul(div(mload(add(data, 0x20)), 0x100000000000000000000000000000000000000000000000000000000), 0x100000000000000000000000000000000000000000000000000000000)
         }
-        
+
         return first4Bytes;
     }
 }

--- a/test/ts/multi_sig_with_time_lock_except_remove_auth_addr.ts
+++ b/test/ts/multi_sig_with_time_lock_except_remove_auth_addr.ts
@@ -33,21 +33,14 @@ contract('MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress', (accounts: s
     validDestination = proxy.address;
   });
 
-  describe('isFunctionRemoveAuthorizedAddress', () => {
-    it('should throw if data is not for removeAuthorizedAddress', async () => {
+  describe('bytes4FromBytes', () => {
+    it('should return the first 4 bytes of a byte array of any size', async () => {
       const data = multiSigWrapper.encodeFnArgs('addAuthorizedAddress', PROXY_ABI, [owners[0]]);
-      try {
-        await multiSig.isFunctionRemoveAuthorizedAddress.call(data);
-        throw new Error('isFunctionRemoveAuthorizedAddress succeeded when it should have failed');
-      } catch (err) {
-        testUtil.assertThrow(err);
-      }
-    });
+      const first4Bytes = await multiSig.bytes4FromBytes(data);
 
-    it('should return true if data is for removeAuthorizedAddress', async () => {
-      const data = multiSigWrapper.encodeFnArgs('removeAuthorizedAddress', PROXY_ABI, [owners[0]]);
-      const isFunctionRemoveAuthorizedAddress = await multiSig.isFunctionRemoveAuthorizedAddress.call(data);
-      assert.equal(isFunctionRemoveAuthorizedAddress, true);
+      const expectedFirst4Bytes = data.slice(0, 10);
+      assert.equal(first4Bytes.length, 10);
+      assert.equal(first4Bytes, expectedFirst4Bytes);
     });
   });
 


### PR DESCRIPTION
- Casts the data byte array into bytes4 for comparison with the `removeAuthorizedAddress` function signature, rather than iterating through the first 4 bytes of the data array and comparing byte-by-byte.
- Fixes issue #94 
- Credit to @GNSPS, PR #96 will be closed after this is merged