### PR TITLE
Small fixes

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -33,7 +33,8 @@ contract Exchange is SafeMath {
         INSUFFICIENT_BALANCE_OR_ALLOWANCE // Insufficient balance or allowance for token transfer
     }
 
-    uint16 constant EXTERNAL_QUERY_GAS_LIMIT = 4999;    // Changes to state require at least 5000 gas
+    string constant public EXCHANGE_VERSION = "1.0.0";
+    uint16 constant public EXTERNAL_QUERY_GAS_LIMIT = 4999;    // Changes to state require at least 5000 gas
 
     address public ZRX_TOKEN_CONTRACT;
     address public PROXY_CONTRACT;

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 
 */
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./Proxy.sol";
 import "./base/Token.sol";

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -111,7 +111,7 @@ contract Exchange is SafeMath {
           bytes32 r,
           bytes32 s)
           public
-          returns (uint)
+          returns (uint filledTakerTokenAmount)
     {
         Order memory order = Order({
             maker: orderAddresses[0],
@@ -143,7 +143,7 @@ contract Exchange is SafeMath {
         }
 
         uint remainingTakerTokenAmount = safeSub(order.takerTokenAmount, getUnavailableTakerTokenAmount(order.orderHash));
-        uint filledTakerTokenAmount = min256(fillTakerTokenAmount, remainingTakerTokenAmount);
+        filledTakerTokenAmount = min256(fillTakerTokenAmount, remainingTakerTokenAmount);
         if (filledTakerTokenAmount == 0) {
             LogError(uint8(Errors.ORDER_FULLY_FILLED_OR_CANCELLED), order.orderHash);
             return 0;

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -110,7 +110,7 @@ contract Exchange is SafeMath {
           bytes32 r,
           bytes32 s)
           public
-          returns (uint filledTakerTokenAmount)
+          returns (uint)
     {
         Order memory order = Order({
             maker: orderAddresses[0],
@@ -142,7 +142,7 @@ contract Exchange is SafeMath {
         }
 
         uint remainingTakerTokenAmount = safeSub(order.takerTokenAmount, getUnavailableTakerTokenAmount(order.orderHash));
-        filledTakerTokenAmount = min256(fillTakerTokenAmount, remainingTakerTokenAmount);
+        uint filledTakerTokenAmount = min256(fillTakerTokenAmount, remainingTakerTokenAmount);
         if (filledTakerTokenAmount == 0) {
             LogError(uint8(Errors.ORDER_FULLY_FILLED_OR_CANCELLED), order.orderHash);
             return 0;
@@ -221,7 +221,7 @@ contract Exchange is SafeMath {
         uint[6] orderValues,
         uint canceltakerTokenAmount)
         public
-        returns (uint cancelledTakerTokenAmount)
+        returns (uint)
     {
         Order memory order = Order({
             maker: orderAddresses[0],
@@ -246,7 +246,7 @@ contract Exchange is SafeMath {
         }
 
         uint remainingTakerTokenAmount = safeSub(order.takerTokenAmount, getUnavailableTakerTokenAmount(order.orderHash));
-        cancelledTakerTokenAmount = min256(canceltakerTokenAmount, remainingTakerTokenAmount);
+        uint cancelledTakerTokenAmount = min256(canceltakerTokenAmount, remainingTakerTokenAmount);
         if (cancelledTakerTokenAmount == 0) {
             LogError(uint8(Errors.ORDER_FULLY_FILLED_OR_CANCELLED), order.orderHash);
             return 0;
@@ -287,7 +287,7 @@ contract Exchange is SafeMath {
         bytes32 r,
         bytes32 s)
         public
-        returns (bool success)
+        returns (bool)
     {
         require(fillOrder(
             orderAddresses,
@@ -319,7 +319,7 @@ contract Exchange is SafeMath {
         bytes32[] r,
         bytes32[] s)
         public
-        returns (bool success)
+        returns (bool)
     {
         for (uint i = 0; i < orderAddresses.length; i++) {
             fillOrder(
@@ -351,7 +351,7 @@ contract Exchange is SafeMath {
         bytes32[] r,
         bytes32[] s)
         public
-        returns (bool success)
+        returns (bool)
     {
         for (uint i = 0; i < orderAddresses.length; i++) {
             fillOrKillOrder(
@@ -384,9 +384,9 @@ contract Exchange is SafeMath {
         bytes32[] r,
         bytes32[] s)
         public
-        returns (uint filledTakerTokenAmount)
+        returns (uint)
     {
-        filledTakerTokenAmount = 0;
+        uint filledTakerTokenAmount = 0;
         for (uint i = 0; i < orderAddresses.length; i++) {
             require(orderAddresses[i][3] == orderAddresses[0][3]); // takerToken must be the same for each order
             filledTakerTokenAmount = safeAdd(filledTakerTokenAmount, fillOrder(
@@ -413,7 +413,7 @@ contract Exchange is SafeMath {
         uint[6][] orderValues,
         uint[] cancelTakerTokenAmounts)
         public
-        returns (bool success)
+        returns (bool)
     {
         for (uint i = 0; i < orderAddresses.length; i++) {
             cancelOrder(
@@ -436,7 +436,7 @@ contract Exchange is SafeMath {
     function getOrderHash(address[5] orderAddresses, uint[6] orderValues)
         public
         constant
-        returns (bytes32 orderHash)
+        returns (bytes32)
     {
         return keccak256(
             address(this),
@@ -469,7 +469,7 @@ contract Exchange is SafeMath {
         bytes32 s)
         public
         constant
-        returns (bool isValid)
+        returns (bool)
     {
         return signer == ecrecover(
             keccak256("\x19Ethereum Signed Message:\n32", hash),
@@ -487,7 +487,7 @@ contract Exchange is SafeMath {
     function isRoundingError(uint numerator, uint denominator, uint target)
         public
         constant
-        returns (bool isError)
+        returns (bool)
     {
         return (target < 10**3 && mulmod(target, numerator, denominator) != 0);
     }
@@ -500,7 +500,7 @@ contract Exchange is SafeMath {
     function getPartialAmount(uint numerator, uint denominator, uint target)
         public
         constant
-        returns (uint partialValue)
+        returns (uint)
     {
         return safeDiv(safeMul(numerator, target), denominator);
     }
@@ -511,7 +511,7 @@ contract Exchange is SafeMath {
     function getUnavailableTakerTokenAmount(bytes32 orderHash)
         public
         constant
-        returns (uint unavailableTakerTokenAmount)
+        returns (uint)
     {
         return safeAdd(filled[orderHash], cancelled[orderHash]);
     }
@@ -533,7 +533,7 @@ contract Exchange is SafeMath {
         address to,
         uint value)
         internal
-        returns (bool success)
+        returns (bool)
     {
         return Proxy(PROXY_CONTRACT).transferFrom(token, from, to, value);
     }
@@ -545,7 +545,7 @@ contract Exchange is SafeMath {
     function isTransferable(Order order, uint fillTakerTokenAmount)
         internal
         constant
-        returns (bool isTransferable)
+        returns (bool)
     {
         address taker = msg.sender;
         uint fillMakerTokenAmount = getPartialAmount(fillTakerTokenAmount, order.takerTokenAmount, order.makerTokenAmount);
@@ -586,7 +586,7 @@ contract Exchange is SafeMath {
     function getBalance(address token, address owner)
         internal
         constant
-        returns (uint balance)
+        returns (uint)
     {
         return Token(token).balanceOf.gas(EXTERNAL_QUERY_GAS_LIMIT)(owner); // Limit gas to prevent reentrancy
     }
@@ -598,7 +598,7 @@ contract Exchange is SafeMath {
     function getAllowance(address token, address owner)
         internal
         constant
-        returns (uint allowance)
+        returns (uint)
     {
         return Token(token).allowance.gas(EXTERNAL_QUERY_GAS_LIMIT)(owner, PROXY_CONTRACT); // Limit gas to prevent reentrancy
     }

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -162,13 +162,13 @@ contract Exchange is SafeMath {
         uint paidMakerFee;
         uint paidTakerFee;
         filled[order.orderHash] = safeAdd(filled[order.orderHash], filledTakerTokenAmount);
-        assert(transferViaProxy(
+        require(transferViaProxy(
             order.makerToken,
             order.maker,
             msg.sender,
             filledMakerTokenAmount
         ));
-        assert(transferViaProxy(
+        require(transferViaProxy(
             order.takerToken,
             msg.sender,
             order.maker,
@@ -177,7 +177,7 @@ contract Exchange is SafeMath {
         if (order.feeRecipient != address(0)) {
             if (order.makerFee > 0) {
                 paidMakerFee = getPartialAmount(filledTakerTokenAmount, order.takerTokenAmount, order.makerFee);
-                assert(transferViaProxy(
+                require(transferViaProxy(
                     ZRX_TOKEN_CONTRACT,
                     order.maker,
                     order.feeRecipient,
@@ -186,7 +186,7 @@ contract Exchange is SafeMath {
             }
             if (order.takerFee > 0) {
                 paidTakerFee = getPartialAmount(filledTakerTokenAmount, order.takerTokenAmount, order.takerFee);
-                assert(transferViaProxy(
+                require(transferViaProxy(
                     ZRX_TOKEN_CONTRACT,
                     msg.sender,
                     order.feeRecipient,
@@ -289,7 +289,7 @@ contract Exchange is SafeMath {
         public
         returns (bool success)
     {
-        assert(fillOrder(
+        require(fillOrder(
             orderAddresses,
             orderValues,
             fillTakerTokenAmount,

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -33,7 +33,7 @@ contract Exchange is SafeMath {
         INSUFFICIENT_BALANCE_OR_ALLOWANCE // Insufficient balance or allowance for token transfer
     }
 
-    string constant public EXCHANGE_VERSION = "1.0.0";
+    string constant public VERSION = "1.0.0";
     uint16 constant public EXTERNAL_QUERY_GAS_LIMIT = 4999;    // Changes to state require at least 5000 gas
 
     address public ZRX_TOKEN_CONTRACT;

--- a/contracts/MultiSigWalletWithTimeLock.sol
+++ b/contracts/MultiSigWalletWithTimeLock.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./base/MultiSigWallet.sol";
 

--- a/contracts/MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress.sol
+++ b/contracts/MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress.sol
@@ -8,8 +8,8 @@ contract MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress is MultiSigWall
 
     modifier validRemoveAuthorizedAddressTx(uint transactionId) {
         Transaction storage tx = transactions[transactionId];
-        assert(tx.destination == PROXY_CONTRACT);
-        assert(isFunctionRemoveAuthorizedAddress(tx.data));
+        require(tx.destination == PROXY_CONTRACT);
+        require(isFunctionRemoveAuthorizedAddress(tx.data));
         _;
     }
 
@@ -57,7 +57,7 @@ contract MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress is MultiSigWall
     {
         bytes4 removeAuthorizedAddressSignature = bytes4(sha3("removeAuthorizedAddress(address)"));
         for (uint i = 0; i < 4; i++) {
-            assert(data[i] == removeAuthorizedAddressSignature[i]);
+            require(data[i] == removeAuthorizedAddressSignature[i]);
         }
         return true;
     }

--- a/contracts/MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress.sol
+++ b/contracts/MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./MultiSigWalletWithTimeLock.sol";
 

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -57,7 +57,7 @@ contract Proxy is Ownable {
         public
         onlyOwner
         targetNotAuthorized(target)
-        returns (bool success)
+        returns (bool)
     {
         authorized[target] = true;
         authorities.push(target);
@@ -72,7 +72,7 @@ contract Proxy is Ownable {
         public
         onlyOwner
         targetAuthorized(target)
-        returns (bool success)
+        returns (bool)
     {
         delete authorized[target];
         for (uint i = 0; i < authorities.length; i++) {
@@ -99,7 +99,7 @@ contract Proxy is Ownable {
         uint value)
         public
         onlyAuthorized
-        returns (bool success)
+        returns (bool)
     {
         return Token(token).transferFrom(from, to, value);
     }

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 
 */
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./base/Token.sol";
 import "./base/Ownable.sol";

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 
 */
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./base/Ownable.sol";
 

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -234,12 +234,12 @@ contract TokenRegistry is Ownable {
         public
         constant
         returns (
-            address,
-            string,
-            string,
-            uint8,
-            bytes,
-            bytes
+            address,  //tokenAddress
+            string,   //name
+            string,   //symbol
+            uint8,    //decimals
+            bytes,    //ipfsHash
+            bytes     //swarmHash
         )
     {
         TokenMetadata memory token = tokens[_token];
@@ -260,12 +260,12 @@ contract TokenRegistry is Ownable {
         public
         constant
         returns (
-            address,
-            string,
-            string,
-            uint8,
-            bytes,
-            bytes
+            address,  //tokenAddress
+            string,   //name
+            string,   //symbol
+            uint8,    //decimals
+            bytes,    //ipfsHash
+            bytes     //swarmHash
         )
     {
         address _token = tokenByName[_name];
@@ -279,12 +279,12 @@ contract TokenRegistry is Ownable {
         public
         constant
         returns (
-            address,
-            string,
-            string,
-            uint8,
-            bytes,
-            bytes
+            address,  //tokenAddress
+            string,   //name
+            string,   //symbol
+            uint8,    //decimals
+            bytes,    //ipfsHash
+            bytes     //swarmHash
         )
     {
         address _token = tokenBySymbol[_symbol];

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -216,14 +216,14 @@ contract TokenRegistry is Ownable {
     /// @dev Provides a registered token's address when given the token symbol.
     /// @param _symbol Symbol of registered token.
     /// @return Token's address.
-    function getTokenAddressBySymbol(string _symbol) constant returns (address tokenAddress) {
+    function getTokenAddressBySymbol(string _symbol) constant returns (address) {
         return tokenBySymbol[_symbol];
     }
 
     /// @dev Provides a registered token's address when given the token name.
     /// @param _name Name of registered token.
     /// @return Token's address.
-    function getTokenAddressByName(string _name) constant returns (address tokenAddress) {
+    function getTokenAddressByName(string _name) constant returns (address) {
         return tokenByName[_name];
     }
 
@@ -234,12 +234,12 @@ contract TokenRegistry is Ownable {
         public
         constant
         returns (
-            address tokenAddress,
-            string name,
-            string symbol,
-            uint8 decimals,
-            bytes ipfsHash,
-            bytes swarmHash
+            address,
+            string,
+            string,
+            uint8,
+            bytes,
+            bytes
         )
     {
         TokenMetadata memory token = tokens[_token];
@@ -260,12 +260,12 @@ contract TokenRegistry is Ownable {
         public
         constant
         returns (
-            address tokenAddress,
-            string name,
-            string symbol,
-            uint8 decimals,
-            bytes ipfsHash,
-            bytes swarmHash
+            address,
+            string,
+            string,
+            uint8,
+            bytes,
+            bytes
         )
     {
         address _token = tokenByName[_name];
@@ -279,12 +279,12 @@ contract TokenRegistry is Ownable {
         public
         constant
         returns (
-            address tokenAddress,
-            string name,
-            string symbol,
-            uint8 decimals,
-            bytes ipfsHash,
-            bytes swarmHash
+            address,
+            string,
+            string,
+            uint8,
+            bytes,
+            bytes
         )
     {
         address _token = tokenBySymbol[_symbol];

--- a/contracts/TokenSaleWithRegistry.sol
+++ b/contracts/TokenSaleWithRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./Exchange.sol";
 import "./tokens/EtherToken.sol";

--- a/contracts/TokenSaleWithRegistry.sol
+++ b/contracts/TokenSaleWithRegistry.sol
@@ -253,7 +253,7 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
     function getOrderHash(address[5] orderAddresses, uint[6] orderValues)
         public
         constant
-        returns (bytes32 orderHash)
+        returns (bytes32)
     {
         return keccak256(
             EXCHANGE_CONTRACT,
@@ -286,7 +286,7 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
         bytes32 s)
         public
         constant
-        returns (bool isValid)
+        returns (bool)
     {
         return pubKey == ecrecover(
             keccak256("\x19Ethereum Signed Message:\n32", hash),

--- a/contracts/TokenSaleWithRegistry.sol
+++ b/contracts/TokenSaleWithRegistry.sol
@@ -49,17 +49,17 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
     }
 
     modifier saleNotInitialized() {
-        assert(!isSaleInitialized);
+        require(!isSaleInitialized);
         _;
     }
 
     modifier saleStarted() {
-        assert(isSaleInitialized && block.timestamp >= startTimeInSec);
+        require(isSaleInitialized && block.timestamp >= startTimeInSec);
         _;
     }
 
     modifier saleNotFinished() {
-        assert(!isSaleFinished);
+        require(!isSaleFinished);
         _;
     }
 
@@ -152,7 +152,7 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
             s
         ));
 
-        assert(ethToken.approve(exchange.PROXY_CONTRACT(), order.takerTokenAmount));
+        require(ethToken.approve(exchange.PROXY_CONTRACT(), order.takerTokenAmount));
         isSaleInitialized = true;
         startTimeInSec = _startTimeInSec;
         baseEthCapPerAddress = _baseEthCapPerAddress;
@@ -176,7 +176,7 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
 
         contributed[msg.sender] = safeAdd(contributed[msg.sender], ethToFill);
 
-        assert(exchange.fillOrKillOrder(
+        require(exchange.fillOrKillOrder(
             [order.maker, order.taker, order.makerToken, order.takerToken, order.feeRecipient],
             [order.makerTokenAmount, order.takerTokenAmount, order.makerFee, order.takerFee, order.expirationTimestampInSec, order.salt],
             ethToFill,
@@ -185,10 +185,10 @@ contract TokenSaleWithRegistry is Ownable, SafeMath {
             order.s
         ));
         uint filledProtocolToken = safeDiv(safeMul(order.makerTokenAmount, ethToFill), order.takerTokenAmount);
-        assert(protocolToken.transfer(msg.sender, filledProtocolToken));
+        require(protocolToken.transfer(msg.sender, filledProtocolToken));
 
         if (ethToFill < msg.value) {
-            assert(msg.sender.send(safeSub(msg.value, ethToFill)));
+            require(msg.sender.send(safeSub(msg.value, ethToFill)));
         }
         if (remainingEth == ethToFill) {
             isSaleFinished = true;

--- a/contracts/base/MultiSigWallet.sol
+++ b/contracts/base/MultiSigWallet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity 0.4.11;
 
 /// @title Multisignature wallet - Allows multiple parties to agree on transactions before execution.
 /// @author Stefan George - <stefan.george@consensys.net>

--- a/contracts/base/Ownable.sol
+++ b/contracts/base/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 /*
  * Ownable

--- a/contracts/base/SafeMath.sol
+++ b/contracts/base/SafeMath.sol
@@ -1,23 +1,23 @@
 pragma solidity 0.4.11;
 
 contract SafeMath {
-    function safeMul(uint a, uint b) internal constant returns (uint) {
+    function safeMul(uint a, uint b) internal constant returns (uint256) {
         uint c = a * b;
         require(a == 0 || c / a == b);
         return c;
     }
 
-    function safeDiv(uint a, uint b) internal constant returns (uint) {
+    function safeDiv(uint a, uint b) internal constant returns (uint256) {
         uint c = a / b;
         return c;
     }
 
-    function safeSub(uint a, uint b) internal constant returns (uint) {
+    function safeSub(uint a, uint b) internal constant returns (uint256) {
         require(b <= a);
         return a - b;
     }
 
-    function safeAdd(uint a, uint b) internal constant returns (uint) {
+    function safeAdd(uint a, uint b) internal constant returns (uint256) {
         uint c = a + b;
         require(c >= a);
         return c;

--- a/contracts/base/SafeMath.sol
+++ b/contracts/base/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 contract SafeMath {
     function safeMul(uint a, uint b) internal constant returns (uint) {

--- a/contracts/base/SafeMath.sol
+++ b/contracts/base/SafeMath.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.11;
 contract SafeMath {
     function safeMul(uint a, uint b) internal constant returns (uint) {
         uint c = a * b;
-        assert(a == 0 || c / a == b);
+        require(a == 0 || c / a == b);
         return c;
     }
 
@@ -13,13 +13,13 @@ contract SafeMath {
     }
 
     function safeSub(uint a, uint b) internal constant returns (uint) {
-        assert(b <= a);
+        require(b <= a);
         return a - b;
     }
 
     function safeAdd(uint a, uint b) internal constant returns (uint) {
         uint c = a + b;
-        assert(c >= a);
+        require(c >= a);
         return c;
     }
 

--- a/contracts/base/StandardToken.sol
+++ b/contracts/base/StandardToken.sol
@@ -4,7 +4,7 @@ import "./Token.sol";
 
 contract StandardToken is Token {
 
-    function transfer(address _to, uint _value) returns (bool success) {
+    function transfer(address _to, uint _value) returns (bool) {
         //Default assumes totalSupply can't be over max (2^256 - 1).
         if (balances[msg.sender] >= _value && balances[_to] + _value >= balances[_to]) {
             balances[msg.sender] -= _value;
@@ -14,7 +14,7 @@ contract StandardToken is Token {
         } else { return false; }
     }
 
-    function transferFrom(address _from, address _to, uint _value) returns (bool success) {
+    function transferFrom(address _from, address _to, uint _value) returns (bool) {
         if (balances[_from] >= _value && allowed[_from][msg.sender] >= _value && balances[_to] + _value >= balances[_to]) {
             balances[_to] += _value;
             balances[_from] -= _value;
@@ -24,17 +24,17 @@ contract StandardToken is Token {
         } else { return false; }
     }
 
-    function balanceOf(address _owner) constant returns (uint balance) {
+    function balanceOf(address _owner) constant returns (uint) {
         return balances[_owner];
     }
 
-    function approve(address _spender, uint _value) returns (bool success) {
+    function approve(address _spender, uint _value) returns (bool) {
         allowed[msg.sender][_spender] = _value;
         Approval(msg.sender, _spender, _value);
         return true;
     }
 
-    function allowance(address _owner, address _spender) constant returns (uint remaining) {
+    function allowance(address _owner, address _spender) constant returns (uint) {
         return allowed[_owner][_spender];
     }
 

--- a/contracts/base/StandardToken.sol
+++ b/contracts/base/StandardToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./Token.sol";
 

--- a/contracts/base/StandardTokenWithOverflowProtection.sol
+++ b/contracts/base/StandardTokenWithOverflowProtection.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.8;
+pragma solidity 0.4.11;
 
 import "./Token.sol";
 import "./SafeMath.sol";

--- a/contracts/base/Token.sol
+++ b/contracts/base/Token.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 contract Token {
 

--- a/contracts/test/DummyToken.sol
+++ b/contracts/test/DummyToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./Mintable.sol";
 import "./../base/Ownable.sol";

--- a/contracts/test/Mintable.sol
+++ b/contracts/test/Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./../base/StandardToken.sol";
 import "./../base/SafeMath.sol";

--- a/contracts/tokens/EtherToken.sol
+++ b/contracts/tokens/EtherToken.sol
@@ -42,6 +42,6 @@ contract EtherToken is StandardTokenWithOverflowProtection {
     {
         balances[msg.sender] = safeSub(balances[msg.sender], amount);
         totalSupply = safeSub(totalSupply, amount);
-        assert(msg.sender.send(amount));
+        require(msg.sender.send(amount));
     }
 }

--- a/contracts/tokens/EtherToken.sol
+++ b/contracts/tokens/EtherToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "../base/StandardTokenWithOverflowProtection.sol";
 

--- a/contracts/tokens/ZRXToken.sol
+++ b/contracts/tokens/ZRXToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./../base/StandardToken.sol";
 


### PR DESCRIPTION
- Make compiler version static (issue #102)
- Change improper uses of `assert` to `require` (issue #103)
- Remove (most) named returns (issue #104)
- Add version string to Exchange (issue #113)