### PR TITLE
Prevent silent token overwrite

### DIFF
--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -71,6 +71,17 @@ contract TokenRegistry is Ownable {
         _;
     }
 
+    modifier nameDoesNotExist(string _name) {
+      require(tokenByName[_name] == address(0));
+      _;
+    }
+
+    modifier symbolDoesNotExist(string _symbol) {
+        require(tokenBySymbol[_symbol] == address(0));
+        _;
+    }
+
+
     /// @dev Allows owner to add a new token to the registry.
     /// @param _token Address of new token.
     /// @param _name Name of new token.
@@ -88,6 +99,8 @@ contract TokenRegistry is Ownable {
         public
         onlyOwner
         tokenDoesNotExist(_token)
+        symbolDoesNotExist(_symbol)
+        nameDoesNotExist(_name)
     {
         tokens[_token] = TokenMetadata({
             token: _token,
@@ -145,6 +158,7 @@ contract TokenRegistry is Ownable {
         public
         onlyOwner
         tokenExists(_token)
+        nameDoesNotExist(_name)
     {
         TokenMetadata storage token = tokens[_token];
         LogTokenNameChange(_token, token.name, _name);
@@ -160,6 +174,7 @@ contract TokenRegistry is Ownable {
         public
         onlyOwner
         tokenExists(_token)
+        symbolDoesNotExist(_symbol)
     {
         TokenMetadata storage token = tokens[_token];
         LogTokenSymbolChange(_token, token.symbol, _symbol);

--- a/test/ts/token_registry.ts
+++ b/test/ts/token_registry.ts
@@ -13,13 +13,25 @@ contract('TokenRegistry', (accounts: string[]) => {
   const owner = accounts[0];
   const notOwner = accounts[1];
 
-  const token = {
-    address: `0x${ethUtil.setLength(ethUtil.toBuffer('0x1'), 20).toString('hex')}`,
-    name: 'testToken',
-    symbol: 'TT',
+  const tokenAddress1 = `0x${ethUtil.setLength(ethUtil.toBuffer('0x1'), 20).toString('hex')}`;
+  const tokenAddress2 = `0x${ethUtil.setLength(ethUtil.toBuffer('0x2'), 20).toString('hex')}`;
+
+  const token1 = {
+    address: tokenAddress1,
+    name: 'testToken1',
+    symbol: 'TT1',
     decimals: 18,
-    ipfsHash: `0x${ethUtil.sha3('test1').toString('hex')}`,
-    swarmHash: `0x${ethUtil.sha3('test2').toString('hex')}`,
+    ipfsHash: `0x${ethUtil.sha3('ipfs1').toString('hex')}`,
+    swarmHash: `0x${ethUtil.sha3('swarm1').toString('hex')}`,
+  };
+
+  const token2 = {
+    address: tokenAddress2,
+    name: 'testToken2',
+    symbol: 'TT2',
+    decimals: 18,
+    ipfsHash: `0x${ethUtil.sha3('ipfs2').toString('hex')}`,
+    swarmHash: `0x${ethUtil.sha3('swarm2').toString('hex')}`,
   };
 
   const nullToken = {
@@ -34,15 +46,15 @@ contract('TokenRegistry', (accounts: string[]) => {
   let tokenReg: ContractInstance;
   let tokenRegWrapper: TokenRegWrapper;
 
-  before(async () => {
-    tokenReg = await TokenRegistry.deployed();
+  beforeEach(async () => {
+    tokenReg = await TokenRegistry.new();
     tokenRegWrapper = new TokenRegWrapper(tokenReg);
   });
 
   describe('addToken', () => {
     it('should throw when not called by owner', async () => {
       try {
-        await tokenRegWrapper.addTokenAsync(token, notOwner);
+        await tokenRegWrapper.addTokenAsync(token1, notOwner);
         throw new Error('addToken succeeded when it should have thrown');
       } catch (err) {
         testUtil.assertThrow(err);
@@ -50,14 +62,40 @@ contract('TokenRegistry', (accounts: string[]) => {
     });
 
     it('should add token metadata when called by owner', async () => {
-      await tokenRegWrapper.addTokenAsync(token, owner);
-      const tokenData = await tokenRegWrapper.getTokenMetaDataAsync(token.address);
-      assert.deepEqual(tokenData, token);
+      await tokenRegWrapper.addTokenAsync(token1, owner);
+      const tokenData = await tokenRegWrapper.getTokenMetaDataAsync(token1.address);
+      assert.deepEqual(tokenData, token1);
     });
 
     it('should throw if token already exists', async () => {
+      await tokenRegWrapper.addTokenAsync(token1, owner);
+
       try {
-        await tokenRegWrapper.addTokenAsync(token, owner);
+        await tokenRegWrapper.addTokenAsync(token1, owner);
+        throw new Error('addToken succeeded when it should have failed');
+      } catch (err) {
+        testUtil.assertThrow(err);
+      }
+    });
+
+    it('should throw if name already exists', async () => {
+      await tokenRegWrapper.addTokenAsync(token1, owner);
+      const duplicateNameToken = _.assign({}, token2, { name: token1.name });
+
+      try {
+        await tokenRegWrapper.addTokenAsync(duplicateNameToken, owner);
+        throw new Error('addToken succeeded when it should have failed');
+      } catch (err) {
+        testUtil.assertThrow(err);
+      }
+    });
+
+    it('should throw if symbol already exists', async () => {
+      await tokenRegWrapper.addTokenAsync(token1, owner);
+      const duplicateSymbolToken = _.assign({}, token2, { symbol: token1.symbol });
+
+      try {
+        await tokenRegWrapper.addTokenAsync(duplicateSymbolToken, owner);
         throw new Error('addToken succeeded when it should have failed');
       } catch (err) {
         testUtil.assertThrow(err);
@@ -65,108 +103,141 @@ contract('TokenRegistry', (accounts: string[]) => {
     });
   });
 
-  describe('getTokenByName', () => {
-    it('should return token metadata when given the token name', async () => {
-      const tokenData = await tokenRegWrapper.getTokenByNameAsync(token.name);
-      assert.deepEqual(tokenData, token);
-    });
-  });
-
-  describe('getTokenBySymbol', () => {
-    it('should return token metadata when given the token symbol', async () => {
-      const tokenData = await tokenRegWrapper.getTokenBySymbolAsync(token.symbol);
-      assert.deepEqual(tokenData, token);
-    });
-  });
-
-  const newNameToken = _.assign({}, token, { name: 'newName' });
-  describe('setTokenName', () => {
-    it('should throw when not called by owner', async () => {
-      try {
-        await tokenReg.setTokenName(token.address, newNameToken.name, { from: notOwner });
-        throw new Error('setTokenName succeeded when it should have thrown');
-      } catch (err) {
-        testUtil.assertThrow(err);
-      }
+  describe('after addToken', () => {
+    beforeEach(async () => {
+      await tokenRegWrapper.addTokenAsync(token1, owner);
     });
 
-    it('should change the token name when called by owner', async () => {
-      const res = await tokenReg.setTokenName(newNameToken.address, newNameToken.name, { from: owner });
-      assert.equal(res.logs.length, 1);
-      const [newData, oldData] = await Promise.all([
-        tokenRegWrapper.getTokenByNameAsync(newNameToken.name),
-        tokenRegWrapper.getTokenByNameAsync(token.name),
-      ]);
-      assert.deepEqual(newData, newNameToken);
-      assert.deepEqual(oldData, nullToken);
+    describe('getTokenByName', () => {
+      it('should return token metadata when given the token name', async () => {
+        const tokenData = await tokenRegWrapper.getTokenByNameAsync(token1.name);
+        assert.deepEqual(tokenData, token1);
+      });
     });
 
-    it('should throw if token does not exist', async () => {
-      try {
-        await tokenReg.setTokenName(nullToken.address, newNameToken.name, { from: owner });
-        throw new Error('setTokenName succeeded when it should have failed');
-      } catch(err) {
-        testUtil.assertThrow(err);
-      }
-    });
-  });
+    describe('getTokenBySymbol', () => {
+      it('should return token metadata when given the token symbol', async () => {
+        const tokenData = await tokenRegWrapper.getTokenBySymbolAsync(token1.symbol);
+        assert.deepEqual(tokenData, token1);
+      });
 
-  const newSymbolToken = _.assign({}, newNameToken, { symbol: 'newSymbol' });
-  describe('setTokenSymbol', () => {
-    it('should throw when not called by owner', async () => {
-      try {
-        await tokenReg.setTokenSymbol(token.address, newSymbolToken.symbol, { from: notOwner });
-        throw new Error('setTokenSymbol succeeded when it should have thrown');
-      } catch (err) {
-        testUtil.assertThrow(err);
-      }
     });
 
-    it('should change the token symbol when called by owner', async () => {
-      const res = await tokenReg.setTokenSymbol(newSymbolToken.address, newSymbolToken.symbol, { from: owner });
-      assert.equal(res.logs.length, 1);
-      const [newData, oldData] = await Promise.all([
-        tokenRegWrapper.getTokenBySymbolAsync(newSymbolToken.symbol),
-        tokenRegWrapper.getTokenBySymbolAsync(token.symbol),
-      ]);
-      assert.deepEqual(newData, newSymbolToken);
-      assert.deepEqual(oldData, nullToken);
+    describe('setTokenName', () => {
+      it('should throw when not called by owner', async () => {
+        try {
+          await tokenReg.setTokenName(token1.address, token2.name, { from: notOwner });
+          throw new Error('setTokenName succeeded when it should have thrown');
+        } catch (err) {
+          testUtil.assertThrow(err);
+        }
+      });
+
+      it('should change the token name when called by owner', async () => {
+        const res = await tokenReg.setTokenName(token1.address, token2.name, { from: owner });
+        assert.equal(res.logs.length, 1);
+        const [newData, oldData] = await Promise.all([
+          tokenRegWrapper.getTokenByNameAsync(token2.name),
+          tokenRegWrapper.getTokenByNameAsync(token1.name),
+        ]);
+
+        const expectedNewData = _.assign({}, token1, { name: token2.name });
+        const expectedOldData = nullToken;
+        assert.deepEqual(newData, expectedNewData);
+        assert.deepEqual(oldData, expectedOldData);
+      });
+
+      it('should throw if the name already exists', async () => {
+        await tokenRegWrapper.addTokenAsync(token2, owner);
+
+        try {
+          await tokenReg.setTokenName(token1.address, token2.name, { from: owner });
+          throw new Error('setTokenName succeeded when it should have failed');
+        } catch (err) {
+          testUtil.assertThrow(err);
+        }
+      });
+
+      it('should throw if token does not exist', async () => {
+        try {
+          await tokenReg.setTokenName(nullToken.address, token2.name, { from: owner });
+          throw new Error('setTokenName succeeded when it should have failed');
+        } catch (err) {
+          testUtil.assertThrow(err);
+        }
+      });
     });
 
-    it('should throw if token does not exist', async () => {
-      try {
-        await tokenReg.setTokenSymbol(nullToken.address, newSymbolToken.symbol, { from: owner });
-        throw new Error('setTokenSymbol succeeded when it should have failed');
-      } catch(err) {
-        testUtil.assertThrow(err);
-      }
-    });
-  });
+    describe('setTokenSymbol', () => {
+      it('should throw when not called by owner', async () => {
+        try {
+          await tokenReg.setTokenSymbol(token1.address, token2.symbol, { from: notOwner });
+          throw new Error('setTokenSymbol succeeded when it should have thrown');
+        } catch (err) {
+          testUtil.assertThrow(err);
+        }
+      });
 
-  describe('removeToken', () => {
-    it('should throw if not called by owner', async () => {
-      try {
-        await tokenReg.removeToken(token.address, { from: notOwner });
-        throw new Error('removeToken succeeded when it should have thrown');
-      } catch (err) {
-        testUtil.assertThrow(err);
-      }
+      it('should change the token symbol when called by owner', async () => {
+        const res = await tokenReg.setTokenSymbol(token1.address, token2.symbol, { from: owner });
+        assert.equal(res.logs.length, 1);
+        const [newData, oldData] = await Promise.all([
+          tokenRegWrapper.getTokenBySymbolAsync(token2.symbol),
+          tokenRegWrapper.getTokenBySymbolAsync(token1.symbol),
+        ]);
+
+        const expectedNewData = _.assign({}, token1, { symbol: token2.symbol });
+        const expectedOldData = nullToken;
+        assert.deepEqual(newData, expectedNewData);
+        assert.deepEqual(oldData, expectedOldData);
+      });
+
+      it('should throw if the symbol already exists', async () => {
+        await tokenRegWrapper.addTokenAsync(token2, owner);
+
+        try {
+          await tokenReg.setTokenSymbol(token1.address, token2.symbol, { from: owner });
+          throw new Error('setTokenSymbol succeeded when it should have failed');
+        } catch (err) {
+          testUtil.assertThrow(err);
+        }
+      });
+
+      it('should throw if token does not exist', async () => {
+        try {
+          await tokenReg.setTokenSymbol(nullToken.address, token2.symbol, { from: owner });
+          throw new Error('setTokenSymbol succeeded when it should have failed');
+        } catch (err) {
+          testUtil.assertThrow(err);
+        }
+      });
     });
 
-    it('should remove token metadata when called by owner', async () => {
-      const res = await tokenReg.removeToken(token.address, { from: owner });
-      assert.equal(res.logs.length, 1);
-      const tokenData = await tokenRegWrapper.getTokenMetaDataAsync(token.address);
-      assert.deepEqual(tokenData, nullToken);
-    });
+    describe('removeToken', () => {
+      it('should throw if not called by owner', async () => {
+        try {
+          await tokenReg.removeToken(token1.address, { from: notOwner });
+          throw new Error('removeToken succeeded when it should have thrown');
+        } catch (err) {
+          testUtil.assertThrow(err);
+        }
+      });
 
-    it('should throw if token does not exist', async () => {
-      try {
-        await tokenReg.removeToken(nullToken.address, { from: owner });
-        throw new Error('removeToken succeeded when it should have failed');
-      } catch(err) {
-        testUtil.assertThrow(err);
-      }
+      it('should remove token metadata when called by owner', async () => {
+        const res = await tokenReg.removeToken(token1.address, { from: owner });
+        assert.equal(res.logs.length, 1);
+        const tokenData = await tokenRegWrapper.getTokenMetaDataAsync(token1.address);
+        assert.deepEqual(tokenData, nullToken);
+      });
+
+      it('should throw if token does not exist', async () => {
+        try {
+          await tokenReg.removeToken(nullToken.address, { from: owner });
+          throw new Error('removeToken succeeded when it should have failed');
+        } catch (err) {
+          testUtil.assertThrow(err);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
- Adds `nameDoesNotExist` and `symbolDoesNotExist` modifiers to prevent accidental overwrites of tokens.
- Refactor and add tests
- Closes issue #115