### PR TITLE
Simplify rounding

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -490,20 +490,12 @@ contract Exchange is SafeMath {
         constant
         returns (bool)
     {
-        if (mulmod(target, numerator, denominator) == 0) return false; // No rounding error.
-        // (numerator * target / denumerator) * 1000000
-        uint partialAmountWithErr = safeMul(getPartialAmount(numerator, denominator, target), 1000000);
-        // (numerator * target * 1000000 / denumerator)
-        uint partialAmountWithoutErr = safeDiv(
-            safeMul(
-                safeMul(numerator, target),
-                1000000
-            ),
-            denominator
-        );
+        uint remainder = mulmod(target, numerator, denominator);
+        if (remainder == 0) return false; // No rounding error.
+
         uint errPercentageTimes1000 = safeDiv(
-            safeSub(partialAmountWithoutErr, partialAmountWithErr), // Absolute rounding error, times 1,000,000
-            safeDiv(partialAmountWithoutErr, 1000)                  // Amount being filled, times 1,000
+            safeMul(remainder, 1000),
+            safeMul(numerator, target)
         );
         return errPercentageTimes1000 > 1;
     }

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -493,11 +493,11 @@ contract Exchange is SafeMath {
         uint remainder = mulmod(target, numerator, denominator);
         if (remainder == 0) return false; // No rounding error.
 
-        uint errPercentageTimes1000 = safeDiv(
+        uint errPercentageTimes1000000 = safeDiv(
             safeMul(remainder, 1000000),
             safeMul(numerator, target)
         );
-        return errPercentageTimes1000 > 1000;
+        return errPercentageTimes1000000 > 1000;
     }
 
     /// @dev Calculates partial value given a numerator and denominator.

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -494,10 +494,10 @@ contract Exchange is SafeMath {
         if (remainder == 0) return false; // No rounding error.
 
         uint errPercentageTimes1000 = safeDiv(
-            safeMul(remainder, 1000),
+            safeMul(remainder, 1000000),
             safeMul(numerator, target)
         );
-        return errPercentageTimes1000 > 1;
+        return errPercentageTimes1000 > 1000;
     }
 
     /// @dev Calculates partial value given a numerator and denominator.

--- a/test/ts/exchange/helpers.ts
+++ b/test/ts/exchange/helpers.ts
@@ -79,6 +79,33 @@ contract('Exchange', (accounts: string[]) => {
   });
 
   describe('isRoundingError', () => {
+    it('should return false if there is a rounding error of 0.1%', async () => {
+      const numerator = new BigNumber(20);
+      const denominator = new BigNumber(999);
+      const target = new BigNumber(50);
+      // rounding error = ((20*50/999) - floor(20*50/999)) / (20*50/999) = 0.1%
+      const isRoundingError = await exchangeWrapper.isRoundingErrorAsync(numerator, denominator, target);
+      assert.equal(isRoundingError, false);
+    });
+
+    it('should return false if there is a rounding of 0.09%', async () => {
+      const numerator = new BigNumber(20);
+      const denominator = new BigNumber(9991);
+      const target = new BigNumber(500);
+      // rounding error = ((20*500/9991) - floor(20*500/9991)) / (20*500/9991) = 0.09%
+      const isRoundingError = await exchangeWrapper.isRoundingErrorAsync(numerator, denominator, target);
+      assert.equal(isRoundingError, false);
+    });
+
+    it('should return true if there is a rounding error of 0.11%', async () => {
+      const numerator = new BigNumber(20);
+      const denominator = new BigNumber(9989);
+      const target = new BigNumber(500);
+      // rounding error = ((20*500/9989) - floor(20*500/9989)) / (20*500/9989) = 0.011%
+      const isRoundingError = await exchangeWrapper.isRoundingErrorAsync(numerator, denominator, target);
+      assert.equal(isRoundingError, true);
+    });
+
     it('should return true if there is a rounding error > 0.1%', async () => {
       const numerator = new BigNumber(3);
       const denominator = new BigNumber(7);


### PR DESCRIPTION
- Simplifies `isRoundingError` (see issue #98 for explanation)
- Note: `errPercentageTimes1000000` is itself susceptible to rounding errors. We can increase precision by multiplying by larger amounts. Currently, the largest possible rounding error is actually 0.10009...%.
- Add boundary tests for `isRoundingError`