### PR TITLE
Final fixes

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -215,12 +215,12 @@ contract Exchange is SafeMath {
     /// @dev Cancels the input order.
     /// @param orderAddresses Array of order's maker, taker, makerToken, takerToken, and feeRecipient.
     /// @param orderValues Array of order's makerTokenAmount, takerTokenAmount, makerFee, takerFee, expirationTimestampInSec, and salt.
-    /// @param canceltakerTokenAmount Desired amount of takerToken to cancel in order.
+    /// @param cancelTakerTokenAmount Desired amount of takerToken to cancel in order.
     /// @return Amount of takerToken cancelled.
     function cancelOrder(
         address[5] orderAddresses,
         uint[6] orderValues,
-        uint canceltakerTokenAmount)
+        uint cancelTakerTokenAmount)
         public
         returns (uint)
     {
@@ -239,7 +239,7 @@ contract Exchange is SafeMath {
         });
 
         require(order.maker == msg.sender);
-        require(order.makerTokenAmount > 0 && order.takerTokenAmount > 0);
+        require(order.makerTokenAmount > 0 && order.takerTokenAmount > 0 && cancelTakerTokenAmount > 0);
 
         if (block.timestamp >= order.expirationTimestampInSec) {
             LogError(uint8(Errors.ORDER_EXPIRED), order.orderHash);
@@ -247,7 +247,7 @@ contract Exchange is SafeMath {
         }
 
         uint remainingTakerTokenAmount = safeSub(order.takerTokenAmount, getUnavailableTakerTokenAmount(order.orderHash));
-        uint cancelledTakerTokenAmount = min256(canceltakerTokenAmount, remainingTakerTokenAmount);
+        uint cancelledTakerTokenAmount = min256(cancelTakerTokenAmount, remainingTakerTokenAmount);
         if (cancelledTakerTokenAmount == 0) {
             LogError(uint8(Errors.ORDER_FULLY_FILLED_OR_CANCELLED), order.orderHash);
             return 0;

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -24,7 +24,7 @@ import "./base/Ownable.sol";
 contract TokenRegistry is Ownable {
 
     event LogAddToken(
-        address token,
+        address indexed token,
         string name,
         string symbol,
         uint8 decimals,
@@ -33,7 +33,7 @@ contract TokenRegistry is Ownable {
     );
 
     event LogRemoveToken(
-        address token,
+        address indexed token,
         string name,
         string symbol,
         uint8 decimals,
@@ -41,10 +41,10 @@ contract TokenRegistry is Ownable {
         bytes swarmHash
     );
 
-    event LogTokenNameChange(address token, string oldName, string newName);
-    event LogTokenSymbolChange(address token, string oldSymbol, string newSymbol);
-    event LogTokenIpfsHashChange(address token, bytes oldIpfsHash, bytes newIpfsHash);
-    event LogTokenSwarmHashChange(address token, bytes oldSwarmHash, bytes newSwarmHash);
+    event LogTokenNameChange(address indexed token, string oldName, string newName);
+    event LogTokenSymbolChange(address indexed token, string oldSymbol, string newSymbol);
+    event LogTokenIpfsHashChange(address indexed token, bytes oldIpfsHash, bytes newIpfsHash);
+    event LogTokenSwarmHashChange(address indexed token, bytes oldSwarmHash, bytes newSwarmHash);
 
     mapping (address => TokenMetadata) public tokens;
     mapping (string => address) tokenBySymbol;

--- a/contracts/TokenSale.sol
+++ b/contracts/TokenSale.sol
@@ -152,7 +152,7 @@ contract TokenSale is Ownable, SafeMath {
         SaleInitialized(_startTimeInSec);
     }
 
-    /// @dev Fills order using msg.value.
+    /// @dev Fills order using msg.value. Should not be called by contracts unless able to access the protocol token after execution.
     function fillOrderWithEth()
         public
         payable

--- a/contracts/TokenSale.sol
+++ b/contracts/TokenSale.sol
@@ -263,15 +263,33 @@ contract TokenSale is Ownable, SafeMath {
         );
     }
 
-    function getOrderHash() public returns (bytes32) {
+    /// @dev Getter function for initialized order's orderHash.
+    /// @return orderHash of initialized order or null.
+    function getOrderHash()
+        public
+        constant
+        returns (bytes32)
+    {
         return order.orderHash;
     }
 
-    function getOrderMakerTokenAmount() public returns (uint) {
+    /// @dev Getter function for initialized order's makerTokenAmount.
+    /// @return makerTokenAmount of initialized order or 0.
+    function getOrderMakerTokenAmount()
+        public
+        constant
+        returns (uint)
+    {
         return order.makerTokenAmount;
     }
 
-    function getOrderTakerTokenAmount() public returns (uint) {
+    /// @dev Getter function for initialized order's takerTokenAmount.
+    /// @return takerTokenAmount of initialized order or 0.
+    function getOrderTakerTokenAmount()
+        public
+        constant
+        returns (uint)
+    {
         return order.takerTokenAmount;
     }
 }

--- a/contracts/TokenSale.sol
+++ b/contracts/TokenSale.sol
@@ -13,9 +13,6 @@ contract TokenSale is Ownable, SafeMath {
 
     uint public constant TIME_PERIOD_IN_SEC = 1 days;
 
-    address public PROTOCOL_TOKEN_CONTRACT;
-    address public ETH_TOKEN_CONTRACT;
-
     Exchange exchange;
     Token protocolToken;
     EtherToken ethToken;
@@ -82,9 +79,6 @@ contract TokenSale is Ownable, SafeMath {
         address _protocolToken,
         address _ethToken)
     {
-        PROTOCOL_TOKEN_CONTRACT = _protocolToken;
-        ETH_TOKEN_CONTRACT = _ethToken;
-
         exchange = Exchange(_exchange);
         protocolToken = Token(_protocolToken);
         ethToken = EtherToken(_ethToken);
@@ -138,8 +132,8 @@ contract TokenSale is Ownable, SafeMath {
         });
 
         require(order.taker == address(this));
-        require(order.makerToken == PROTOCOL_TOKEN_CONTRACT);
-        require(order.takerToken == ETH_TOKEN_CONTRACT);
+        require(order.makerToken == address(protocolToken));
+        require(order.takerToken == address(ethToken));
         require(order.feeRecipient == address(0));
 
         require(isValidSignature(

--- a/contracts/base/SafeMath.sol
+++ b/contracts/base/SafeMath.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.11;
 contract SafeMath {
     function safeMul(uint a, uint b) internal constant returns (uint256) {
         uint c = a * b;
-        require(a == 0 || c / a == b);
+        assert(a == 0 || c / a == b);
         return c;
     }
 
@@ -13,13 +13,13 @@ contract SafeMath {
     }
 
     function safeSub(uint a, uint b) internal constant returns (uint256) {
-        require(b <= a);
+        assert(b <= a);
         return a - b;
     }
 
     function safeAdd(uint a, uint b) internal constant returns (uint256) {
         uint c = a + b;
-        require(c >= a);
+        assert(c >= a);
         return c;
     }
 

--- a/test/ts/exchange/core.ts
+++ b/test/ts/exchange/core.ts
@@ -643,6 +643,17 @@ contract('Exchange', (accounts: string[]) => {
       }
     });
 
+    it('should throw if cancelTakerTokenAmount is 0', async () => {
+      order = await orderFactory.newSignedOrderAsync();
+
+      try {
+        await exWrapper.cancelOrderAsync(order, maker, { cancelTakerTokenAmount: new BigNumber(0) });
+        throw new Error('Cancel succeeded when it should have thrown');
+      } catch (err) {
+        testUtil.assertThrow(err);
+      }
+    });
+
     it('should be able to cancel a full order', async () => {
       await exWrapper.cancelOrderAsync(order, maker);
       await exWrapper.fillOrderAsync(order, taker, { fillTakerTokenAmount: order.params.takerTokenAmount.div(2) });


### PR DESCRIPTION
- Adds check to see if `cancelTakerTokenAmount` is greater than `0` (issue #101)
- Removes unnecessary constants in `TokenSale` (issue #138)
- Adds comment on `fillOrderWithEth` (issue #139)
- Adds `constant` modifier to getter functions in `TokenSale` (issue #137)
- Changes SafeMath overflow checks to asserts
- Indexes `token` in TokenRegistry events