### PR TITLE
TokenRegistry improvements

### DIFF
--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -131,18 +131,16 @@ contract TokenRegistry is Ownable {
 
     /// @dev Allows owner to remove an existing token from the registry.
     /// @param _token Address of existing token.
-    function removeToken(address _token)
+    function removeToken(address _token, uint _index)
         public
         onlyOwner
         tokenExists(_token)
     {
-        for (uint i = 0; i < tokenAddresses.length; i++) {
-            if (tokenAddresses[i] == _token) {
-                tokenAddresses[i] = tokenAddresses[tokenAddresses.length - 1];
-                tokenAddresses.length -= 1;
-                break;
-            }
-        }
+        require(tokenAddresses[_index] == _token);
+
+        tokenAddresses[_index] = tokenAddresses[tokenAddresses.length - 1];
+        tokenAddresses.length -= 1;
+
         TokenMetadata storage token = tokens[_token];
         LogRemoveToken(
             token.token,

--- a/contracts/TokenRegistry.sol
+++ b/contracts/TokenRegistry.sol
@@ -81,6 +81,11 @@ contract TokenRegistry is Ownable {
         _;
     }
 
+    modifier addressNotNull(address _address) {
+        require(_address != address(0));
+        _;
+    }
+
 
     /// @dev Allows owner to add a new token to the registry.
     /// @param _token Address of new token.
@@ -99,6 +104,7 @@ contract TokenRegistry is Ownable {
         public
         onlyOwner
         tokenDoesNotExist(_token)
+        addressNotNull(_token)
         symbolDoesNotExist(_symbol)
         nameDoesNotExist(_name)
     {

--- a/test/ts/token_registry.ts
+++ b/test/ts/token_registry.ts
@@ -225,7 +225,7 @@ contract('TokenRegistry', (accounts: string[]) => {
     describe('removeToken', () => {
       it('should throw if not called by owner', async () => {
         try {
-          await tokenReg.removeToken(token1.address, { from: notOwner });
+          await tokenReg.removeToken(token1.address, 0, { from: notOwner });
           throw new Error('removeToken succeeded when it should have thrown');
         } catch (err) {
           testUtil.assertThrow(err);
@@ -233,7 +233,7 @@ contract('TokenRegistry', (accounts: string[]) => {
       });
 
       it('should remove token metadata when called by owner', async () => {
-        const res = await tokenReg.removeToken(token1.address, { from: owner });
+        const res = await tokenReg.removeToken(token1.address, 0, { from: owner });
         assert.equal(res.logs.length, 1);
         const tokenData = await tokenRegWrapper.getTokenMetaDataAsync(token1.address);
         assert.deepEqual(tokenData, nullToken);
@@ -241,12 +241,22 @@ contract('TokenRegistry', (accounts: string[]) => {
 
       it('should throw if token does not exist', async () => {
         try {
-          await tokenReg.removeToken(nullToken.address, { from: owner });
+          await tokenReg.removeToken(nullToken.address, 0, { from: owner });
           throw new Error('removeToken succeeded when it should have failed');
         } catch (err) {
           testUtil.assertThrow(err);
         }
       });
+
+      it('should throw if token at given index does not match address', async () => {
+        try {
+          await tokenReg.removeToken(nullToken.address, 1, { from: owner });
+          throw new Error('removeToken succeeded when it should have failed');
+        } catch (err) {
+          testUtil.assertThrow(err);
+        }
+      });
+
     });
   });
 });

--- a/test/ts/token_registry.ts
+++ b/test/ts/token_registry.ts
@@ -249,8 +249,10 @@ contract('TokenRegistry', (accounts: string[]) => {
       });
 
       it('should throw if token at given index does not match address', async () => {
+        await tokenRegWrapper.addTokenAsync(token2, owner);
+
         try {
-          await tokenReg.removeToken(nullToken.address, 1, { from: owner });
+          await tokenReg.removeToken(token2.address, 0, { from: owner });
           throw new Error('removeToken succeeded when it should have failed');
         } catch (err) {
           testUtil.assertThrow(err);

--- a/test/ts/token_registry.ts
+++ b/test/ts/token_registry.ts
@@ -78,6 +78,15 @@ contract('TokenRegistry', (accounts: string[]) => {
       }
     });
 
+    it('should throw if token address is null', async () => {
+      try {
+        await tokenRegWrapper.addTokenAsync(nullToken, owner);
+        throw new Error('addToken succeeded when it should have failed');
+      } catch (err) {
+        testUtil.assertThrow(err);
+      }
+    });
+
     it('should throw if name already exists', async () => {
       await tokenRegWrapper.addTokenAsync(token1, owner);
       const duplicateNameToken = _.assign({}, token2, { name: token1.name });


### PR DESCRIPTION
As discussed with @abandeali1 in emails: 

1. Checkers for duplicated addresses, names and symbols used in modifiers:
   require(tokens[_token].token != address(0));

check for "0x" value which is both a valid address and default empty value. As "0x" is used as a special address for avoiding fee payments it may be tempting to register it as a special "null token". Later, the name or symbol may be overwritten to point to a different malicious address that will collect all of the "0x" fee payment. It'd be a better practice to either prevent registering "0x" address or distinguishing between null and "0x" value.


2. Function removeToken(address _token) 
     is getting more and more expensive with every new token added to the storage (820gas per token). Although the hard cap is pretty high (8k with current block limit) it's correctness depends on block limit set be miners. It can easily fixed to have constant running cost.

